### PR TITLE
[WIP] Feature/prop types refactoring

### DIFF
--- a/src/AdminBuilder.js
+++ b/src/AdminBuilder.js
@@ -10,23 +10,25 @@ import Edit from './Edit';
 export default class AdminBuilder extends Component {
   static propTypes = {
     api: React.PropTypes.instanceOf(Api).isRequired,
-    restClient: React.PropTypes.func.isRequired,
+    ...Admin.propTypes,
   };
 
   render() {
-    return <Admin title={this.props.api.title} restClient={this.props.restClient}>
-        {this.props.api.resources.map(resource =>
-          <Resource
-            options={{api: this.props.api, resource}}
-            key={resource.name}
-            name={resource.name}
-            list={List}
-            show={Show}
-            create={Create}
-            edit={Edit}
-            remove={Delete}
-          />
-        )}
-      </Admin>;
+    const { api , ...props } = this.props;
+
+    return <Admin title={api.title} {...props}>
+      {api.resources.map(resource =>
+        <Resource
+          options={{api: this.props.api, resource}}
+          key={resource.name}
+          name={resource.name}
+          list={List}
+          show={Show}
+          create={Create}
+          edit={Edit}
+          remove={Delete}
+        />
+      )}
+    </Admin>;
   }
 }

--- a/src/Create.js
+++ b/src/Create.js
@@ -1,8 +1,17 @@
 import React, {Component} from 'react';
 import {Create as BaseCreate, SimpleForm} from 'admin-on-rest/lib/mui';
+import Resource from 'api-doc-parser/lib/Resource';
 import inputFactory from './inputFactory';
 
 export default class Create extends Component {
+  static propTypes = {
+    options: React.PropTypes.shape({
+      inputFactory: React.PropTypes.func,
+      resource: React.PropTypes.instanceOf(Resource),
+    }),
+    ...BaseCreate.propTypes,
+  };
+
   render() {
     const factory = this.props.options.inputFactory ? this.props.options.inputFactory : inputFactory;
 

--- a/src/Edit.js
+++ b/src/Edit.js
@@ -1,8 +1,17 @@
 import React, {Component} from 'react';
 import {Edit as BaseEdit, SimpleForm, DisabledInput} from 'admin-on-rest/lib/mui';
+import Resource from 'api-doc-parser/lib/Resource';
 import inputFactory from './inputFactory';
 
 export default class Edit extends Component {
+  static propTypes = {
+    options: React.PropTypes.shape({
+      inputFactory: React.PropTypes.func,
+      resource: React.PropTypes.instanceOf(Resource),
+    }),
+    ...BaseEdit.propTypes,
+  };
+
   render() {
     const factory = this.props.options.inputFactory ? this.props.options.inputFactory : inputFactory;
 

--- a/src/List.js
+++ b/src/List.js
@@ -1,13 +1,19 @@
 import React, {Component} from 'react';
 import {List as BaseList, Datagrid, TextField, ShowButton, EditButton} from 'admin-on-rest/lib/mui';
+import Resource from 'api-doc-parser/lib/Resource';
 import fieldFactory from './fieldFactory';
 
 export default class List extends Component {
   static defaultProps = {
     perPage: 30 // Default value in API Platform
   };
+
   static propTypes = {
-    perPage: React.PropTypes.number
+    options: React.PropTypes.shape({
+      inputFactory: React.PropTypes.func,
+      resource: React.PropTypes.instanceOf(Resource),
+    }),
+    ...BaseList.propTypes,
   };
 
   render() {

--- a/src/Show.js
+++ b/src/Show.js
@@ -1,8 +1,17 @@
 import React, {Component} from 'react';
 import {Show as BaseShow, SimpleShowLayout, TextField} from 'admin-on-rest/lib/mui';
+import Resource from 'api-doc-parser/lib/Resource';
 import fieldFactory from './fieldFactory';
 
 export default class Show extends Component {
+  static propTypes = {
+    options: React.PropTypes.shape({
+      inputFactory: React.PropTypes.func,
+      resource: React.PropTypes.instanceOf(Resource),
+    }),
+    ...BaseShow.propTypes,
+  };
+
   render() {
     const factory = this.props.options.fieldFactory ? this.props.options.fieldFactory : fieldFactory;
 


### PR DESCRIPTION
Hi there,

I'm adding better and more flexible `propTypes` validation based on existing  [admin-on-rest](https://github.com/marmelab/admin-on-rest/blob/master/src/Admin.js#L116) `propTypes`.
This way you won't have to maintain propTypes that you don't own.

It also fix customization issues of an `Admin` inside an `AdminBuilder` by passing down all props to child component except the custom ones.

I could go further down this road, for example by creating a dedicated `customPropTypes.js` file and reduce duplication:
```
export const options = {
  inputFactory: React.PropTypes.func,
  resource: React.PropTypes.instanceOf(Resource),
})
```
That's currently a WIP, but I'd like to hear from you before moving any further.
Also what's your plan for this project? Do you plan to split this up as suggested in #5 ?

Cheers.