### PR TITLE
Fix JsonLd to AOR document transformation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "api-doc-parser": "^0.1",
     "babel-runtime": "^6.23",
     "jsonld": "^0.4",
-    "lodash.isplainobject": "^4.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isplainobject": "^4.0.6",
     "prop-types": "~15.5.7",
     "react": "~15.5.4",
     "react-dom": "~15.5.4"

--- a/src/hydra/hydraClient.test.js
+++ b/src/hydra/hydraClient.test.js
@@ -1,6 +1,6 @@
 import { transformJsonLdToAOR } from './hydraClient';
 
-describe('map a json-ld document to an admin on rest compatible document', function() {
+describe('map a json-ld document to an admin on rest compatible document', () => {
   const jsonLdDocument = {
     "@id": "/reviews/327",
     "id": 327,
@@ -16,10 +16,24 @@ describe('map a json-ld document to an admin on rest compatible document', funct
       "description": "string",
       "author": "string",
       "dateCreated": "2017-04-25T00:00:00+00:00",
-    }
+    },
+    "comment": [
+      {
+        "@id": "/comments/1",
+        "@type": "http://schema.org/Comment",
+        "text": "Lorem ipsum dolor sit amet.",
+        "dateCreated": "2017-04-26T00:00:00+00:00",
+      },
+      {
+        "@id": "/comments/2",
+        "@type": "http://schema.org/Comment",
+        "text": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+        "dateCreated": "2017-04-27T00:00:00+00:00",
+      }
+    ]
   };
 
-  describe('transform only the main document when called with a max depth of 1', function() {
+  describe('transform only the main document when called with a max depth of 1', () => {
     const AORDocument = transformJsonLdToAOR(1)(jsonLdDocument);
 
     test('add an id property equal to the original @id property', () => {
@@ -31,15 +45,25 @@ describe('map a json-ld document to an admin on rest compatible document', funct
     });
 
     test('do not alter the embedded document', () => {
-      expect(AORDocument.id).toEqual(jsonLdDocument['id']);
+      expect(AORDocument.itemReviewed.id).toEqual(jsonLdDocument.itemReviewed.id);
     });
   });
 
-  describe('transform the embedded document when called with a max depth of 2', function() {
-    const AORDocument = transformJsonLdToAOR()(jsonLdDocument);
+  describe('transform the embedded document when called with a max depth of 2', () => {
+    const AORDocument = transformJsonLdToAOR(2)(jsonLdDocument);
 
     test('add an id property on the embedded document equal to the @id property of the embedded document', () => {
       expect(AORDocument.itemReviewed.id).toEqual(AORDocument.itemReviewed['@id']);
+    });
+  });
+
+  describe('transform the embedded document collection when called with a max depth of 3', () => {
+    const AORDocument = transformJsonLdToAOR(3)(jsonLdDocument);
+
+    test('add an id property on each document of an embedded collection equal to the @id property', () => {
+      AORDocument.comment.forEach(comment => {
+        expect(comment.id).toEqual(comment['@id']);
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,7 +2702,11 @@ lodash.get@~4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash.isplainobject@^4.0:
+lodash.isarray@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
+
+lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 


### PR DESCRIPTION
Embedded resources and collections are now transformed correctly.

Previous tests were flawed because `transformJsonLdToAOR` was mutating the original document.
Implementation has been changed to deal with this and tests were added to ensure that each resource of a collection are also transformed.