### PR TITLE
Fix deletion

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -72,7 +72,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
    *
    * @returns {Promise}
    */
-  const convertAORDataToHydraData = (resource, data) => {
+  const convertAORDataToHydraData = (resource, data = {}) => {
     resource = resources.find(({name}) => resource === name);
     if (undefined === resource) {
       return Promise.resolve(data);
@@ -172,7 +172,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
    *
    * @returns {Promise}
    */
-  const convertHydraDataToAORData = (resource, data) => {
+  const convertHydraDataToAORData = (resource, data = {}) => {
     resource = resources.find(({name}) => resource === name);
     if (undefined === resource) {
       return Promise.resolve(data);


### PR DESCRIPTION
`admin-on-rest` requires a `data` property in response but `DELETE` response does not contain any `data` node.

In this fix, I add a default value to `convertAORDataToHydraData` and `convertHydraDataToAORData`. If `data` node is missing (it will be `undefined`), `{}` will be used as value of `data`.