### PR TITLE
transformJsonLdToAOR: Fix depth issue

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -34,15 +34,13 @@ export const transformJsonLdDocumentToAORDocument = (
       });
 
   if (depth < maxDepth) {
-    depth++;
-
     if (isArray(documents)) {
       documents = documents.map(document =>
-        transformJsonLdDocumentToAORDocument(maxDepth, depth)(document),
+        transformJsonLdDocumentToAORDocument(maxDepth, depth+1)(document),
       );
     } else {
       Object.keys(documents).forEach(key => {
-        documents[key] = transformJsonLdDocumentToAORDocument(maxDepth, depth)(
+        documents[key] = transformJsonLdDocumentToAORDocument(maxDepth, depth+1)(
           documents[key],
         );
       });


### PR DESCRIPTION
I hard-vendored a previous version of hydraClient in my project and just had to fix a bug where the incrementation of the `depth` variable caused issues when transforming an array of documents. 

`depth` could quickly jump to a number far superior than `maxDepth`. It caused the `id` to not be included in the sub-documents. The fix was to not increment the depth variable itself but to pass `depth+1` to the recursive call. 

That work for me and I thought I would contribute back this fix to the original project. I did not test it though. But as you can see, the fix is trivial and I'm pretty sure it's ok (*famous last words ;)*)

