### PR TITLE
Handle error during api documentation parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "admin-on-rest": "^1.1",
-    "api-doc-parser": "^0.1.7",
+    "api-doc-parser": "^0.2.0",
     "babel-runtime": "^6.23",
     "jsonld": "^0.4",
     "lodash.isplainobject": "^4.0.6",

--- a/src/hydra/HydraAdmin.js
+++ b/src/hydra/HydraAdmin.js
@@ -7,34 +7,70 @@ import restClient from './hydraClient';
 class HydraAdmin extends Component {
   static defaultProps = {
     apiDocumentationParser,
+    customRoutes: [],
+    error: 'Unable to retrieve API documentation.',
+    loading: 'Loading...',
     restClient,
   };
 
   static propTypes = {
     apiDocumentationParser: PropTypes.func,
+    customRoutes: PropTypes.array,
     entrypoint: PropTypes.string.isRequired,
+    error: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+    loading: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     restClient: PropTypes.func,
   };
 
   state = {
     api: null,
+    customRoutes: [],
+    hasError: false,
+    loaded: false,
   };
 
   componentDidMount() {
     this.props
       .apiDocumentationParser(this.props.entrypoint)
-      .then(api => this.setState({api}));
+      .then(
+        ({api, customRoutes = []}) => ({
+          api,
+          customRoutes,
+          hasError: false,
+          loaded: true,
+        }),
+        ({api, customRoutes = []}) => ({
+          api,
+          customRoutes,
+          hasError: true,
+          loaded: true,
+        }),
+      )
+      .then(this.setState.bind(this));
   }
 
   render() {
-    if (null === this.state.api) {
-      return <span>Loading...</span>;
+    if (false === this.state.loaded) {
+      return 'function' === typeof this.props.loading
+        ? <this.props.loading />
+        : <span className="loading">
+            {this.props.loading}
+          </span>;
+    }
+
+    if (true === this.state.hasError) {
+      return 'function' === typeof this.props.error
+        ? <this.props.error />
+        : <span className="error">
+            {this.props.error}
+          </span>;
     }
 
     return (
       <AdminBuilder
         {...this.props}
         api={this.state.api}
+        customRoutes={this.props.customRoutes.concat(this.state.customRoutes)}
         restClient={this.props.restClient(this.state.api)}
       />
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,9 +115,9 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
-api-doc-parser@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/api-doc-parser/-/api-doc-parser-0.1.7.tgz#b55697a92b425b2118e7dcd14f9d444b7e10f673"
+api-doc-parser@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/api-doc-parser/-/api-doc-parser-0.2.0.tgz#7751ec1b7b377cd91be7698b360b7829bb234c33"
   dependencies:
     babel-runtime "^6.23.0"
     jsonld "^0.4.11"


### PR DESCRIPTION
This PR should fix issues #43 and #31.

---

This PR handles parsing errors (see [my PR on dunglas/api-doc-parser](https://github.com/dunglas/api-doc-parser/pull/13)):
* if the parsing is resolved, the "classic" behavior is kept (rendering `AdminBuilder`).
* if the parsing is rejected, a message will be shown.

In all cases, the user has the possibility to define some `customRoutes`. These routes will be added to the `customRoutes` defined via properties.

---

With this PR, we can now use `api-platform/admin` on a fully secured API. For example:

```js
import { AUTH_ERROR, AUTH_LOGIN, AUTH_LOGOUT } from 'admin-on-rest';
import parseHydraDocumentation from 'api-doc-parser/lib/hydra/parseHydraDocumentation';
import { fetchHydra as baseFetchHydra, HydraAdmin, hydraClient as baseHydraClient } from 'api-platform-admin';
import React from 'react';
import { Redirect } from 'react-router-dom';

// Define constants

const ENTRYPOINT = 'http://127.0.0.1:8000';
const LOCAL_STORAGE_KEY_TOKEN = 'token';

// Define restClient

const fetchHeaders = {
    'Authorization': `Bearer ${window.localStorage.getItem(LOCAL_STORAGE_KEY_TOKEN)}`,
};

const fetchHydra = (url, options = {}) => baseFetchHydra(url, {
    ...options,
    headers: new Headers(fetchHeaders),
});

const restClient = api => baseHydraClient(api, fetchHydra);

// Define authClient

const authClient = (type, params) => {
    switch (type) {
        case AUTH_ERROR:
            if (401 === params.status || 403 === params.status) {
                window.localStorage.removeItem(LOCAL_STORAGE_KEY_TOKEN);
                window.location.reload();
                break;
            }

            return Promise.resolve();

        case AUTH_LOGIN:
            const body = new FormData();
            body.append('username', params.username);
            body.append('password', params.password);

            const request = new Request(`${ENTRYPOINT}/login`, {
                method: 'POST',
                body,
            });

            return fetch(request)
                .then(response => {
                    if (response.status < 200 || response.status >= 300) {
                        throw new Error(response.statusText);
                    }

                    return response.json();
                })
                .then(({ token }) => {
                    window.localStorage.setItem(LOCAL_STORAGE_KEY_TOKEN, token);
                    window.location.replace('/');
                });

        case AUTH_LOGOUT:
            window.localStorage.removeItem(LOCAL_STORAGE_KEY_TOKEN);

            return Promise.resolve();

        default:
            return Promise.resolve();
    }
};

// Define apiDocumentationParser

const apiDocumentationParser = entrypoint => parseHydraDocumentation(entrypoint, { headers: new Headers(fetchHeaders) })
    .then(
        ({ api }) => ({ api }),
        (result) => {
            switch (result.status) {
                case 401:
                    return Promise.resolve({
                        api: result.api,
                        customRoutes: [
                            {
                                props: {
                                    path: '/',
                                    render: () => (
                                        <Redirect to={`/login`}/>
                                    ),
                                },
                            },
                        ],
                    });

                default:
                    return Promise.reject(result);
            }
        },
    );


// Render administration

export default props => (
    <HydraAdmin
        apiDocumentationParser={apiDocumentationParser}
        authClient={authClient}
        entrypoint={ENTRYPOINT}
        restClient={restClient}
    />
);
```

In this example:
* we add a `customRoute` if parsing returned a `401` error. This route will redirect to the `login` page.
* the `authClient` will refresh current page when a JWT token will be stored. Refresh the page will give the possibility to parse again the documentation, but this time the JWT token will be sent.