### PR TITLE
Sync deps with Admin On Rest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,11 @@
     "babel-runtime": "^6.23",
     "jsonld": "^0.4",
     "lodash.isplainobject": "^4.0.6",
-    "prop-types": "~15.5.7",
+    "prop-types": "^15.5.7",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
+  },
+  "peerDependencies": {
     "react": "^15.4.0 || ^16.0.0-beta.5",
     "react-dom": "^15.4.0 || ^16.0.0-beta.5"
   },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Sync React version with the one used to build Admin On Rest. Fix the `Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's ``render`` method, or you have multiple copies of React loaded` error introduced by #53. 
