### PR TITLE
Each element in a response of a GET_MANY request had a 'data' key 

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -242,7 +242,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
     if (GET_MANY === type) {
       return Promise.all(
         params.ids.map(id => fetchApi(GET_ONE, resource, {id})),
-      ).then(responses => ({data: responses}));
+      ).then(responses => ({data: responses.map(response => response.data)}));
     }
 
     return convertAORRequestToHydraRequest(type, resource, params)

--- a/src/hydra/hydraClient.test.js
+++ b/src/hydra/hydraClient.test.js
@@ -1,4 +1,5 @@
-import {transformJsonLdDocumentToAORDocument} from './hydraClient';
+import hydraClient, {transformJsonLdDocumentToAORDocument} from './hydraClient';
+import {GET_MANY} from 'admin-on-rest';
 
 describe('map a json-ld document to an admin on rest compatible document', () => {
   const jsonLdDocument = {
@@ -70,6 +71,22 @@ describe('map a json-ld document to an admin on rest compatible document', () =>
       AORDocument.comment.forEach(comment => {
         expect(comment.id).toEqual(comment['@id']);
       });
+    });
+  });
+});
+
+describe('fetch data from an hydra api', () => {
+  test('fetch a get_many resource', async () => {
+    const mockHttpClient = jest.fn();
+    mockHttpClient
+      .mockReturnValueOnce(Promise.resolve({json: {'@id': 'books/3'}}))
+      .mockReturnValue(Promise.resolve({json: {'@id': 'books/5'}}));
+
+    await hydraClient({entrypoint: '/'}, mockHttpClient)(GET_MANY, 'books', {
+      ids: [3, 5],
+    }).then(response => {
+      expect(response.data[0].id).toEqual('books/3');
+      expect(response.data[1].id).toEqual('books/5');
     });
   });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Before a request like this:
`GET_MANY books`
```json
{
  "ids": ["books/1","books/3"]
}
```
was returning:
```json
{
  "data": [
    {"data": {"@id": "books/1", "id": "books/1"}},
    {"data": {"@id": "books/3", "id": "books/3"}},
  ]
}
```
But it should return:
```json
{
  "data": [
    {"@id": "books/1", "id": "books/1"},
    {"@id": "books/3", "id": "books/3"},
  ]
}
```

The fields were not correctly interpreted by admin-on-rest.