### PR TITLE
Customize CRUD components

### DIFF
--- a/src/AdminBuilder.js
+++ b/src/AdminBuilder.js
@@ -1,38 +1,62 @@
-import React, {Component} from 'react';
-import PropTypes from 'prop-types';
-import {Admin, Resource, Delete} from 'admin-on-rest';
 import Api from '@api-platform/api-doc-parser/lib/Api';
-import List from './List';
-import Show from './Show';
+import {Admin, Delete, Resource} from 'admin-on-rest';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Create from './Create';
 import Edit from './Edit';
+import fieldFactory from './fieldFactory';
+import inputFactory from './inputFactory';
+import List from './List';
+import Show from './Show';
 
-export default class extends Component {
-  static propTypes = {
-    api: PropTypes.instanceOf(Api).isRequired,
-    restClient: PropTypes.func.isRequired,
-  };
+const AdminBuilder = props => {
+  const {api, fieldFactory, inputFactory, title = api.title} = props;
 
-  render() {
-    let props = {...this.props};
-    if (!props.title) props.title = this.props.api.title;
-
-    return (
-      <Admin {...props}>
-        {this.props.api.resources.map(resource => (
+  return (
+    <Admin {...props} title={title}>
+      {api.resources.map(resource => {
+        const {
+          create = Create,
+          edit = Edit,
+          list = List,
+          name,
+          props,
+          remove = Delete,
+          show = Show,
+        } = resource;
+        return (
           <Resource
-            options={{api: this.props.api, resource}}
-            key={resource.name}
-            name={resource.name}
-            list={List}
-            show={Show}
-            create={Create}
-            edit={Edit}
-            remove={Delete}
-            {...resource.props}
+            {...props}
+            create={create}
+            edit={edit}
+            key={name}
+            list={list}
+            name={name}
+            options={{
+              api,
+              fieldFactory,
+              inputFactory,
+              resource,
+            }}
+            remove={remove}
+            show={show}
           />
-        ))}
-      </Admin>
-    );
-  }
-}
+        );
+      })}
+    </Admin>
+  );
+};
+
+AdminBuilder.defaultProps = {
+  fieldFactory,
+  inputFactory,
+};
+
+AdminBuilder.propTypes = {
+  api: PropTypes.instanceOf(Api).isRequired,
+  fieldFactory: PropTypes.func,
+  inputFactory: PropTypes.func,
+  restClient: PropTypes.func.isRequired,
+};
+
+export default AdminBuilder;

--- a/src/Create.js
+++ b/src/Create.js
@@ -1,26 +1,33 @@
-import React, {Component} from 'react';
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
 import {Create as BaseCreate, SimpleForm} from 'admin-on-rest';
-import inputFactory from './inputFactory';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-export default class extends Component {
-  render() {
-    const factory = this.props.options.inputFactory
-      ? this.props.options.inputFactory
-      : inputFactory;
+const Create = props => {
+  const {options: {api, inputFactory, resource}} = props;
 
-    return (
-      <BaseCreate {...this.props}>
-        <SimpleForm>
-          {this.props.options.resource.writableFields.map(field =>
-            factory(
-              field,
-              this.props.options.resource,
-              'create',
-              this.props.options.api,
-            ),
-          )}
-        </SimpleForm>
-      </BaseCreate>
-    );
-  }
-}
+  return (
+    <BaseCreate {...props}>
+      <SimpleForm>
+        {resource.writableFields.map(field =>
+          inputFactory(field, {
+            action: 'create',
+            api,
+            resource,
+          }),
+        )}
+      </SimpleForm>
+    </BaseCreate>
+  );
+};
+
+Create.propTypes = {
+  options: PropTypes.shape({
+    api: PropTypes.instanceOf(Api).isRequired,
+    inputFactory: PropTypes.func.isRequired,
+    resource: PropTypes.instanceOf(Resource).isRequired,
+  }),
+};
+
+export default Create;

--- a/src/Edit.js
+++ b/src/Edit.js
@@ -1,27 +1,34 @@
-import React, {Component} from 'react';
-import {Edit as BaseEdit, SimpleForm, DisabledInput} from 'admin-on-rest';
-import inputFactory from './inputFactory';
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
+import {DisabledInput, Edit as BaseEdit, SimpleForm} from 'admin-on-rest';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-export default class extends Component {
-  render() {
-    const factory = this.props.options.inputFactory
-      ? this.props.options.inputFactory
-      : inputFactory;
+const Edit = props => {
+  const {options: {api, inputFactory, resource}} = props;
 
-    return (
-      <BaseEdit {...this.props}>
-        <SimpleForm>
-          <DisabledInput source="id" />
-          {this.props.options.resource.writableFields.map(field =>
-            factory(
-              field,
-              this.props.options.resource,
-              'edit',
-              this.props.options.api,
-            ),
-          )}
-        </SimpleForm>
-      </BaseEdit>
-    );
-  }
-}
+  return (
+    <BaseEdit {...props}>
+      <SimpleForm>
+        <DisabledInput source="id" />
+        {resource.writableFields.map(field =>
+          inputFactory(field, {
+            action: 'edit',
+            api,
+            resource,
+          }),
+        )}
+      </SimpleForm>
+    </BaseEdit>
+  );
+};
+
+Edit.propTypes = {
+  options: PropTypes.shape({
+    api: PropTypes.instanceOf(Api).isRequired,
+    inputFactory: PropTypes.func.isRequired,
+    resource: PropTypes.instanceOf(Resource).isRequired,
+  }),
+};
+
+export default Edit;

--- a/src/List.js
+++ b/src/List.js
@@ -1,43 +1,49 @@
-import React, {Component} from 'react';
-import PropTypes from 'prop-types';
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
 import {
-  List as BaseList,
   Datagrid,
-  TextField,
-  ShowButton,
   EditButton,
+  List as BaseList,
+  ShowButton,
+  TextField,
 } from 'admin-on-rest';
-import fieldFactory from './fieldFactory';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-export default class extends Component {
-  static defaultProps = {
-    perPage: 30, // Default value in API Platform
-  };
-  static propTypes = {
-    perPage: PropTypes.number,
-  };
+const List = props => {
+  const {hasEdit, hasShow, options: {api, fieldFactory, resource}} = props;
 
-  render() {
-    const factory = this.props.options.fieldFactory
-      ? this.props.options.fieldFactory
-      : fieldFactory;
+  return (
+    <BaseList {...props}>
+      <Datagrid>
+        <TextField source="id" />
+        {resource.readableFields.map(field =>
+          fieldFactory(field, {
+            action: 'list',
+            api,
+            resource,
+          }),
+        )}
+        {hasShow && <ShowButton />}
+        {hasEdit && <EditButton />}
+      </Datagrid>
+    </BaseList>
+  );
+};
 
-    return (
-      <BaseList {...this.props}>
-        <Datagrid>
-          <TextField source="id" />
-          {this.props.options.resource.readableFields.map(field =>
-            factory(
-              field,
-              this.props.options.resource,
-              'list',
-              this.props.options.api,
-            ),
-          )}
-          <ShowButton />
-          <EditButton />
-        </Datagrid>
-      </BaseList>
-    );
-  }
-}
+List.defaultProps = {
+  perPage: 30, // Default value in API Platform
+};
+
+List.propTypes = {
+  options: PropTypes.shape({
+    api: PropTypes.instanceOf(Api).isRequired,
+    fieldFactory: PropTypes.func.isRequired,
+    resource: PropTypes.instanceOf(Resource).isRequired,
+  }),
+  perPage: PropTypes.number,
+  hasEdit: PropTypes.bool.isRequired,
+  hasShow: PropTypes.bool.isRequired,
+};
+
+export default List;

--- a/src/Show.js
+++ b/src/Show.js
@@ -1,27 +1,34 @@
-import React, {Component} from 'react';
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
 import {Show as BaseShow, SimpleShowLayout, TextField} from 'admin-on-rest';
-import fieldFactory from './fieldFactory';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-export default class extends Component {
-  render() {
-    const factory = this.props.options.fieldFactory
-      ? this.props.options.fieldFactory
-      : fieldFactory;
+const Show = props => {
+  const {options: {api, fieldFactory, resource}} = props;
 
-    return (
-      <BaseShow {...this.props}>
-        <SimpleShowLayout>
-          <TextField source="id" />
-          {this.props.options.resource.readableFields.map(field =>
-            factory(
-              field,
-              this.props.options.resource,
-              'show',
-              this.props.options.api,
-            ),
-          )}
-        </SimpleShowLayout>
-      </BaseShow>
-    );
-  }
-}
+  return (
+    <BaseShow {...props}>
+      <SimpleShowLayout>
+        <TextField source="id" />
+        {resource.readableFields.map(field =>
+          fieldFactory(field, {
+            action: 'show',
+            api,
+            resource,
+          }),
+        )}
+      </SimpleShowLayout>
+    </BaseShow>
+  );
+};
+
+Show.propTypes = {
+  options: PropTypes.shape({
+    api: PropTypes.instanceOf(Api).isRequired,
+    fieldFactory: PropTypes.func.isRequired,
+    resource: PropTypes.instanceOf(Resource).isRequired,
+  }),
+};
+
+export default Show;

--- a/src/fieldFactory.js
+++ b/src/fieldFactory.js
@@ -1,63 +1,48 @@
-import React from 'react';
 import {
+  BooleanField,
+  DateField,
+  EmailField,
+  NumberField,
   ReferenceField,
   TextField,
-  EmailField,
-  DateField,
-  NumberField,
-  BooleanField,
 } from 'admin-on-rest';
+import React from 'react';
 
-const getFieldFromId = id => {
-  if ('http://schema.org/email' === id) {
-    return EmailField;
-  }
-
-  return null;
-};
-
-const getFieldFromRange = range => {
-  switch (range) {
-    case 'http://www.w3.org/2001/XMLSchema#integer':
-    case 'http://www.w3.org/2001/XMLSchema#float':
-      return NumberField;
-
-    case 'http://www.w3.org/2001/XMLSchema#date':
-    case 'http://www.w3.org/2001/XMLSchema#dateTime':
-      return DateField;
-
-    case 'http://www.w3.org/2001/XMLSchema#boolean':
-      return BooleanField;
-
-    default:
-      return TextField;
-  }
-};
-
-export default field => {
-  // To customize the field
-  if (field.fieldComponent) {
-    return field.fieldComponent;
+export default (field, options) => {
+  if (field.field) {
+    return (
+      <field.field key={field.name} options={options} source={field.name} />
+    );
   }
 
   if (null !== field.reference) {
     return (
       <ReferenceField
-        source={field.name}
-        reference={field.reference.name}
         key={field.name}
-        {...field.fieldProps}>
+        reference={field.reference.name}
+        source={field.name}>
         <TextField source="id" />
       </ReferenceField>
     );
   }
 
-  let FieldType;
+  if ('http://schema.org/email' === field.id) {
+    return <EmailField key={field.name} source={field.name} />;
+  }
 
-  FieldType = getFieldFromId(field.id);
-  if (null === FieldType) FieldType = getFieldFromRange(field.range);
+  switch (field.range) {
+    case 'http://www.w3.org/2001/XMLSchema#integer':
+    case 'http://www.w3.org/2001/XMLSchema#float':
+      return <NumberField key={field.name} source={field.name} />;
 
-  return (
-    <FieldType source={field.name} key={field.name} {...field.fieldProps} />
-  );
+    case 'http://www.w3.org/2001/XMLSchema#date':
+    case 'http://www.w3.org/2001/XMLSchema#dateTime':
+      return <DateField key={field.name} source={field.name} />;
+
+    case 'http://www.w3.org/2001/XMLSchema#boolean':
+      return <BooleanField key={field.name} source={field.name} />;
+
+    default:
+      return <TextField key={field.name} source={field.name} />;
+  }
 };

--- a/src/hydra/fetchHydra.js
+++ b/src/hydra/fetchHydra.js
@@ -6,7 +6,7 @@ import {promises} from 'jsonld';
 /**
  * Sends HTTP requests to a Hydra API.
  *
- * Adapted from AdminBuilder On Rest
+ * Adapted from admin-on-rest
  *
  * @copyright Kévin Dunglas
  *

--- a/src/inputFactory.js
+++ b/src/inputFactory.js
@@ -1,63 +1,47 @@
-import React from 'react';
 import {
-  DateInput,
-  TextInput,
-  NumberInput,
   BooleanInput,
+  DateInput,
+  NumberInput,
   ReferenceInput,
   SelectInput,
+  TextInput,
 } from 'admin-on-rest';
+import React from 'react';
 
-export default input => {
-  // To customize the input
-  if (input.inputComponent) {
-    return input.inputComponent;
+export default (field, options) => {
+  if (field.input) {
+    return (
+      <field.input key={field.name} options={options} source={field.name} />
+    );
   }
 
-  let props = {...input.inputProps};
-  if (!props.validate)
-    props.validate = value => (value ? undefined : 'Required');
-
-  if (null !== input.reference) {
+  if (null !== field.reference) {
     return (
       <ReferenceInput
-        source={input.name}
-        label={input.name}
-        reference={input.reference.name}
-        key={input.name}
-        allowEmpty
-        {...props}>
+        key={field.name}
+        label={field.name}
+        reference={field.reference.name}
+        source={field.name}>
         <SelectInput optionText="id" />
       </ReferenceInput>
     );
   }
 
-  let InputType;
-  switch (input.range) {
+  switch (field.range) {
     case 'http://www.w3.org/2001/XMLSchema#integer':
-      InputType = NumberInput;
-      break;
+      return <NumberInput key={field.name} source={field.name} />;
 
     case 'http://www.w3.org/2001/XMLSchema#decimal':
-      InputType = NumberInput;
-      props.step = '0.1';
-      break;
+      return <NumberInput key={field.name} source={field.name} step="0.1" />;
 
     case 'http://www.w3.org/2001/XMLSchema#boolean':
-      if ((!input.inputProps || !input.inputProps.validate) && input.required)
-        props.validate = undefined;
-      InputType = BooleanInput;
-      break;
+      return <BooleanInput key={field.name} source={field.name} />;
 
     case 'http://www.w3.org/2001/XMLSchema#date':
     case 'http://www.w3.org/2001/XMLSchema#dateTime':
-      InputType = DateInput;
-      break;
+      return <DateInput key={field.name} source={field.name} />;
 
     default:
-      InputType = TextInput;
-      break;
+      return <TextInput key={field.name} source={field.name} />;
   }
-
-  return <InputType source={input.name} key={input.name} {...props} />;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes (remove `fieldComponent` and `inputComponent`)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #38
| License       | MIT
| Doc PR        | not yet

__Note__: PR #7 should be useless after merging this PR.

---

With this PR, we give the possibility to users to customize:
* the components used by `Resource` (`Create`, `Edit`, `List`, `Remove` and `Show`).
* the factories (`fieldFactory` and `inputFactory`).

---

To change a CRUD component, we just have to define them in `api`:
* `api.resources[key of the resource].create` to change `Create`.
* `api.resources[key of the resource].edit` to change `Edit`.
* `api.resources[key of the resource].list` to change `List`.
* `api.resources[key of the resource].remove` to change `Remove`.
* `api.resources[key of the resource].show` to change `Show`.

I removed `fieldComponent` and `inputComponent`. IMO:
* the suffix `Component` is incorrect because there are not components.
* all customization in this project can be done by component (CRUD component, `HydraAdmin::error` and `HydraAdmin::loading`).

Here an example of usage:

```js
import parseHydraDocumentation from '@api-platform/api-doc-parser/lib/hydra/parseHydraDocumentation';
import { Datagrid, EditButton, ImageField, List, ShowButton, TextField } from 'admin-on-rest';
import React from 'react';
import SingleImageInput from '../components/inputs/single-image-input';

export default entrypoint => parseHydraDocumentation(entrypoint)
    .then(
        ({ api }) => {

            // Customize "Gallery" resource

            const gallery = api.resources.find(({ name }) => 'galleries' === name);

            gallery.list = (props) => (
                <List {...props}>
                    <Datagrid>
                        <TextField source="id"/>
                        {props.options.fieldFactory(props.options.resource.fields.find(({ name }) => name === 'name'))}
                        {props.options.fieldFactory(props.options.resource.fields.find(({ name }) => name === 'mainImage'))}
                        {props.hasShow && <ShowButton />}
                        {props.hasEdit && <EditButton />}
                    </Datagrid>
                </List>
            );

            // Customize "images" field

            const images = gallery.fields.find(({ name }) => 'images' === name);

            images.field = props => (
                <ImageField {...props} src="contentUrl"/>
            );

            images.input = props => (
                <SingleImageInput {...props} accept="image/*" multiple={true}>
                    <ImageField source="contentUrl"/>
                </SingleImageInput>
            );

            images.input.defaultProps = {
                addField: true,
                addLabel: true,
            };

            // Customize "mainImage" field

            const mainImage = gallery.fields.find(({ name }) => 'mainImage' === name);

            mainImage.field = props => (
                <ImageField {...props} source={`${props.source}.contentUrl`}/>
            );

            mainImage.input = props => (
                <SingleImageInput {...props} accept="image/*" multiple={false}>
                    <ImageField source="contentUrl"/>
                </SingleImageInput>
            );

            mainImage.input.defaultProps = {
                addField: true,
                addLabel: true,
            };

            mainImage.input.defaultProps = {
                addField: true,
                addLabel: true,
            };

            return { api };
        },
    );
```

---

To change `fieldComponent` or `inputComponent`, we just have to define them in `HydraAdmin`:

```js
import { HydraAdmin } from '@api-platform/admin';
import React from 'react';

export default props => (
    <HydraAdmin
        entrypoint='http://localhost:8000'
        fieldFactory={(field) => {
            // return an field
        }}
        inputFactory={(field) => {
            // return an input
        }}
    />
);
```

I removed usage of `inputProps` and `fieldProps`: if the user wants to change `props`, he / she has to define the component in `api.resources[...].fields[key of the field].input` our `api.resources[...].fields[key of the field].field`.