### PR TITLE
Remove react from dependency and add it to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "eslint-plugin-react": "^7.1",
     "jest": "^20.0",
     "prettier": "^1.5.2",
-    "raf": "^3.3.2"
+    "raf": "^3.3.2",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "dependencies": {
     "@api-platform/api-doc-parser": "^0.3.1",
@@ -41,13 +43,11 @@
     "babel-runtime": "^6.23",
     "jsonld": "^0.4",
     "lodash.isplainobject": "^4.0.6",
-    "prop-types": "^15.5.7",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "react": "^15.4.0 || ^16.0.0-beta.5",
-    "react-dom": "^15.4.0 || ^16.0.0-beta.5"
+    "react": "^15.4.0 || ^16.0.0",
+    "react-dom": "^15.4.0 || ^16.0.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

React should not be in `dependencies` but in `devDependencies`.
This should resolve the issue "You may have multiple copies of React loaded." when updating to React 16.
