### PR TITLE
Fix dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ export default App;
 
 ## Documentation
 
-The documentation of API Platform Admin can be browsed [on the official website](https://api-platform.com/docs/admin/).
+The documentation of API Platform Admin can be browsed [on the official website](https://api-platform.com/docs/admin/index#the-api-platform-admin).
 
 ## Credits
 


### PR DESCRIPTION
The actual link in documentation is dead.

The current url for the admin documentation is : https://api-platform.com/docs/admin/index#the-api-platform-admin

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #72
| License       | MIT
| Doc PR        | 
