### PR TITLE
Manage "order" in hydraClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "babel-runtime": "^6.23",
     "jsonld": "^0.4",
     "lodash.isplainobject": "^4.0.6",
-    "prop-types": "^15.5.7"
+    "prop-types": "^15.5.7",
+    "qs": "^6.5.1"
   },
   "peerDependencies": {
     "react": "^15.4.0 || ^16.0.0",

--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -1,7 +1,6 @@
 import {
   CREATE,
   DELETE,
-  fetchUtils,
   GET_LIST,
   GET_MANY,
   GET_MANY_REFERENCE,
@@ -9,6 +8,7 @@ import {
   UPDATE,
 } from 'admin-on-rest';
 import isPlainObject from 'lodash.isplainobject';
+import qs from 'qs';
 import fetchHydra from './fetchHydra';
 
 /**
@@ -125,12 +125,15 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
         });
 
       case GET_LIST: {
-        const {pagination: {page}} = params;
+        const {pagination: {page}, sort: {field, order}} = params;
 
         return Promise.resolve({
           options: {},
-          url: `${entrypoint}/${resource}?${fetchUtils.queryParameters({
+          url: `${entrypoint}/${resource}?${qs.stringify({
             ...params.filter,
+            order: {
+              [field]: order,
+            },
             page,
           })}`,
         });
@@ -139,7 +142,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
       case GET_MANY_REFERENCE:
         return Promise.resolve({
           options: {},
-          url: `${entrypoint}/${resource}?${fetchUtils.queryParameters({
+          url: `${entrypoint}/${resource}?${qs.stringify({
             [params.target]: params.id,
           })}`,
         });

--- a/src/hydra/hydraClient.test.js
+++ b/src/hydra/hydraClient.test.js
@@ -1,5 +1,5 @@
+import {GET_LIST, GET_MANY} from 'admin-on-rest';
 import hydraClient, {transformJsonLdDocumentToAORDocument} from './hydraClient';
-import {GET_MANY} from 'admin-on-rest';
 
 describe('map a json-ld document to an admin on rest compatible document', () => {
   const jsonLdDocument = {
@@ -76,6 +76,26 @@ describe('map a json-ld document to an admin on rest compatible document', () =>
 });
 
 describe('fetch data from an hydra api', () => {
+  test('fetch a get_list resource', async () => {
+    const mockHttpClient = jest.fn();
+    mockHttpClient.mockReturnValue(
+      Promise.resolve({
+        json: {
+          'hydra:member': [{'@id': 'books/5'}],
+        },
+      }),
+    );
+
+    await hydraClient({entrypoint: ''}, mockHttpClient)(GET_LIST, 'books', {
+      pagination: {page: 2},
+      sort: {field: 'id', order: 'ASC'},
+    }).then(() => {
+      expect(mockHttpClient.mock.calls[0][0]).toBe(
+        '/books?order%5Bid%5D=ASC&page=2',
+      );
+    });
+  });
+
   test('fetch a get_many resource', async () => {
     const mockHttpClient = jest.fn();
     mockHttpClient

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,13 +3295,13 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+qs@^6.5.1, qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 query-string@~5.0.0:
   version "5.0.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR gives the possibility to order entries in `List` view.

I use [qs](https://github.com/ljharb/qs) instead of `admin-on-rest::fetchUtils::queryParameters` (alias for [query-string](https://github.com/sindresorhus/query-string)) because it does not manage nested level (see https://github.com/sindresorhus/query-string/issues/100 and https://github.com/sindresorhus/query-string#nesting)