### PR TITLE
add GET_MANY_REFERENCE case to convertHydraResponseToAORResponse

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -208,6 +208,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
   const convertHydraResponseToAORResponse = (type, resource, response) => {
     switch (type) {
       case GET_LIST:
+      case GET_MANY_REFERENCE:
         // TODO: support other prefixes than "hydra:"
         return Promise.resolve(
           response.json['hydra:member'].map(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR resolve a problem i had while i wanted to list all resources where i had a relation to a subresource on a custom view. 

Now i can do this : 
List all occurences of event at this address.
![image](https://user-images.githubusercontent.com/15939709/36636598-e3cc3926-19c9-11e8-8cb9-0a65ce6edfc1.png)
