### PR TITLE
Add the possibility to customize CRUD components

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-preset-es2015": "^6.0",
     "babel-preset-react": "^6.0",
     "babel-preset-stage-0": "^6.0",
+    "enzyme": "^2.9.1",
     "eslint": "^3.0",
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-flowtype": "^2.34.1",
@@ -35,7 +36,8 @@
     "prettier": "^1.5.2",
     "raf": "^3.3.2",
     "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react-dom": "^15.6.1",
+    "react-test-renderer": "^15.6.1"
   },
   "dependencies": {
     "@api-platform/api-doc-parser": "^0.3.2",

--- a/src/AdminBuilder.js
+++ b/src/AdminBuilder.js
@@ -7,7 +7,13 @@ import inputFactory from './inputFactory';
 import resourceFactory from './resourceFactory';
 
 const AdminBuilder = props => {
-  const {api, fieldFactory, inputFactory, title = api.title} = props;
+  const {
+    api,
+    fieldFactory,
+    inputFactory,
+    resourceFactory,
+    title = api.title,
+  } = props;
 
   return (
     <Admin {...props} title={title}>
@@ -21,12 +27,14 @@ const AdminBuilder = props => {
 AdminBuilder.defaultProps = {
   fieldFactory,
   inputFactory,
+  resourceFactory,
 };
 
 AdminBuilder.propTypes = {
   api: PropTypes.instanceOf(Api).isRequired,
   fieldFactory: PropTypes.func,
   inputFactory: PropTypes.func,
+  resourceFactory: PropTypes.func,
   restClient: PropTypes.func.isRequired,
 };
 

--- a/src/Create.js
+++ b/src/Create.js
@@ -4,15 +4,35 @@ import {Create as BaseCreate, SimpleForm} from 'admin-on-rest';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+const resolveProps = props => {
+  const {options} = props;
+  const {inputFactory: defaultInputFactory, resource} = options;
+  const {
+    createFields: customFields,
+    createProps = {},
+    writableFields: defaultFields,
+  } = resource;
+  const {options: {inputFactory: customInputFactory} = {}} = createProps;
+
+  return {
+    ...props,
+    ...createProps,
+    options: {
+      ...options,
+      fields: customFields || defaultFields,
+      inputFactory: customInputFactory || defaultInputFactory,
+    },
+  };
+};
+
 const Create = props => {
-  const {options: {api, inputFactory, resource}} = props;
+  const {options: {api, fields, inputFactory, resource}} = resolveProps(props);
 
   return (
     <BaseCreate {...props}>
       <SimpleForm>
-        {resource.writableFields.map(field =>
+        {fields.map(field =>
           inputFactory(field, {
-            action: 'create',
             api,
             resource,
           }),

--- a/src/Create.test.js
+++ b/src/Create.test.js
@@ -1,0 +1,135 @@
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Field from '@api-platform/api-doc-parser/lib/Field';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
+import {TextInput} from 'admin-on-rest';
+import {shallow} from 'enzyme';
+import React from 'react';
+import Create from './Create';
+import inputFactory from './inputFactory';
+
+const entrypoint = 'http://entrypoint';
+
+const apiData = {
+  entrypoint,
+};
+
+const resourceData = {
+  name: 'user',
+  url: `${entrypoint}/users`,
+  writableFields: [
+    new Field('fieldA', {
+      id: 'http://schema.org/fieldA',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+    new Field('fieldB', {
+      id: 'http://schema.org/fieldB',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+  ],
+};
+
+describe('<Create />', () => {
+  test('without overrides', () => {
+    const defaultInputFactory = jest.fn(inputFactory);
+
+    const resource = new Resource(
+      resourceData.name,
+      resourceData.url,
+      resourceData,
+    );
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Create
+        options={{
+          api,
+          inputFactory: defaultInputFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultInputFactory).toHaveBeenCalledTimes(2);
+    expect(render.find(TextInput).length).toEqual(2);
+    expect(render.find(TextInput).get(0).props.source).toEqual('fieldA');
+    expect(render.find(TextInput).get(1).props.source).toEqual('fieldB');
+  });
+
+  test('with custom inputFactory', () => {
+    const customInputFactory = jest.fn(inputFactory);
+    const defaultInputFactory = jest.fn(inputFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      createProps: {
+        options: {
+          inputFactory: customInputFactory,
+        },
+      },
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Create
+        options={{
+          api,
+          inputFactory: defaultInputFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(customInputFactory).toHaveBeenCalledTimes(2);
+    expect(defaultInputFactory).toHaveBeenCalledTimes(0);
+    expect(render.find(TextInput).length).toEqual(2);
+    expect(render.find(TextInput).get(0).props.source).toEqual('fieldA');
+    expect(render.find(TextInput).get(1).props.source).toEqual('fieldB');
+  });
+
+  test('with custom fields', () => {
+    const defaultInputFactory = jest.fn(inputFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      createFields: [
+        new Field('fieldC', {
+          id: 'http://schema.org/fieldC',
+          range: 'http://www.w3.org/2001/XMLSchema#string',
+          reference: null,
+          required: true,
+        }),
+      ],
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Create
+        options={{
+          api,
+          inputFactory: defaultInputFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultInputFactory).toHaveBeenCalledTimes(1);
+    expect(render.find(TextInput).length).toEqual(1);
+    expect(render.find(TextInput).get(0).props.source).toEqual('fieldC');
+  });
+});

--- a/src/Edit.js
+++ b/src/Edit.js
@@ -4,16 +4,36 @@ import {DisabledInput, Edit as BaseEdit, SimpleForm} from 'admin-on-rest';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+const resolveProps = props => {
+  const {options} = props;
+  const {inputFactory: defaultInputFactory, resource} = options;
+  const {
+    editFields: customFields,
+    editProps = {},
+    writableFields: defaultFields,
+  } = resource;
+  const {options: {inputFactory: customInputFactory} = {}} = editProps;
+
+  return {
+    ...props,
+    ...editProps,
+    options: {
+      ...options,
+      fields: customFields || defaultFields,
+      inputFactory: customInputFactory || defaultInputFactory,
+    },
+  };
+};
+
 const Edit = props => {
-  const {options: {api, inputFactory, resource}} = props;
+  const {options: {api, fields, inputFactory, resource}} = resolveProps(props);
 
   return (
     <BaseEdit {...props}>
       <SimpleForm>
         <DisabledInput source="id" />
-        {resource.writableFields.map(field =>
+        {fields.map(field =>
           inputFactory(field, {
-            action: 'edit',
             api,
             resource,
           }),

--- a/src/Edit.test.js
+++ b/src/Edit.test.js
@@ -1,0 +1,135 @@
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Field from '@api-platform/api-doc-parser/lib/Field';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
+import {TextInput} from 'admin-on-rest';
+import {shallow} from 'enzyme';
+import React from 'react';
+import Edit from './Edit';
+import inputFactory from './inputFactory';
+
+const entrypoint = 'http://entrypoint';
+
+const apiData = {
+  entrypoint,
+};
+
+const resourceData = {
+  name: 'user',
+  url: `${entrypoint}/users`,
+  writableFields: [
+    new Field('fieldA', {
+      id: 'http://schema.org/fieldA',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+    new Field('fieldB', {
+      id: 'http://schema.org/fieldB',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+  ],
+};
+
+describe('<Edit />', () => {
+  test('without overrides', () => {
+    const defaultInputFactory = jest.fn(inputFactory);
+
+    const resource = new Resource(
+      resourceData.name,
+      resourceData.url,
+      resourceData,
+    );
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Edit
+        options={{
+          api,
+          inputFactory: defaultInputFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultInputFactory).toHaveBeenCalledTimes(2);
+    expect(render.find(TextInput).length).toEqual(2);
+    expect(render.find(TextInput).get(0).props.source).toEqual('fieldA');
+    expect(render.find(TextInput).get(1).props.source).toEqual('fieldB');
+  });
+
+  test('with custom inputFactory', () => {
+    const customInputFactory = jest.fn(inputFactory);
+    const defaultInputFactory = jest.fn(inputFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      editProps: {
+        options: {
+          inputFactory: customInputFactory,
+        },
+      },
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Edit
+        options={{
+          api,
+          inputFactory: defaultInputFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(customInputFactory).toHaveBeenCalledTimes(2);
+    expect(defaultInputFactory).toHaveBeenCalledTimes(0);
+    expect(render.find(TextInput).length).toEqual(2);
+    expect(render.find(TextInput).get(0).props.source).toEqual('fieldA');
+    expect(render.find(TextInput).get(1).props.source).toEqual('fieldB');
+  });
+
+  test('with custom fields', () => {
+    const defaultInputFactory = jest.fn(inputFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      editFields: [
+        new Field('fieldC', {
+          id: 'http://schema.org/fieldC',
+          range: 'http://www.w3.org/2001/XMLSchema#string',
+          reference: null,
+          required: true,
+        }),
+      ],
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Edit
+        options={{
+          api,
+          inputFactory: defaultInputFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultInputFactory).toHaveBeenCalledTimes(1);
+    expect(render.find(TextInput).length).toEqual(1);
+    expect(render.find(TextInput).get(0).props.source).toEqual('fieldC');
+  });
+});

--- a/src/List.js
+++ b/src/List.js
@@ -10,16 +10,41 @@ import {
 import PropTypes from 'prop-types';
 import React from 'react';
 
+const resolveProps = props => {
+  const {options} = props;
+  const {fieldFactory: defaultFieldFactory, resource} = options;
+  const {
+    listFields: customFields,
+    listProps = {},
+    readableFields: defaultFields,
+  } = resource;
+  const {options: {fieldFactory: customFieldFactory} = {}} = listProps;
+
+  return {
+    ...props,
+    ...listProps,
+    options: {
+      ...options,
+      fieldFactory: customFieldFactory || defaultFieldFactory,
+      fields: customFields || defaultFields,
+    },
+  };
+};
+
 const List = props => {
-  const {hasEdit, hasShow, options: {api, fieldFactory, resource}} = props;
+  const {
+    addIdField,
+    hasEdit,
+    hasShow,
+    options: {api, fieldFactory, fields, resource},
+  } = resolveProps(props);
 
   return (
     <BaseList {...props}>
       <Datagrid>
-        <TextField source="id" />
-        {resource.readableFields.map(field =>
+        {addIdField && <TextField source="id" />}
+        {fields.map(field =>
           fieldFactory(field, {
-            action: 'list',
             api,
             resource,
           }),
@@ -32,13 +57,16 @@ const List = props => {
 };
 
 List.defaultProps = {
+  addIdField: true,
   perPage: 30, // Default value in API Platform
 };
 
 List.propTypes = {
+  addIdField: PropTypes.bool,
   options: PropTypes.shape({
     api: PropTypes.instanceOf(Api).isRequired,
     fieldFactory: PropTypes.func.isRequired,
+    listProps: PropTypes.object,
     resource: PropTypes.instanceOf(Resource).isRequired,
   }),
   perPage: PropTypes.number,

--- a/src/List.test.js
+++ b/src/List.test.js
@@ -1,0 +1,169 @@
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Field from '@api-platform/api-doc-parser/lib/Field';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
+import {TextField} from 'admin-on-rest';
+import {shallow} from 'enzyme';
+import React from 'react';
+import fieldFactory from './fieldFactory';
+import List from './List';
+
+const entrypoint = 'http://entrypoint';
+
+const apiData = {
+  entrypoint,
+};
+
+const resourceData = {
+  name: 'user',
+  readableFields: [
+    new Field('fieldA', {
+      id: 'http://schema.org/fieldA',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+    new Field('fieldB', {
+      id: 'http://schema.org/fieldB',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+  ],
+  url: `${entrypoint}/users`,
+};
+
+describe('<List />', () => {
+  test('without overrides', () => {
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(
+      resourceData.name,
+      resourceData.url,
+      resourceData,
+    );
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <List
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(2);
+    expect(render.find(TextField).length).toEqual(3);
+    expect(render.find(TextField).get(0).props.source).toEqual('id');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldA');
+    expect(render.find(TextField).get(2).props.source).toEqual('fieldB');
+  });
+
+  test('without adding ID', () => {
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      listProps: {
+        addIdField: false,
+      },
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <List
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(2);
+    expect(render.find(TextField).length).toEqual(2);
+    expect(render.find(TextField).get(0).props.source).toEqual('fieldA');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldB');
+  });
+
+  test('with custom fieldFactory', () => {
+    const customFieldFactory = jest.fn(fieldFactory);
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      listProps: {
+        options: {
+          fieldFactory: customFieldFactory,
+        },
+      },
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <List
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(customFieldFactory).toHaveBeenCalledTimes(2);
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(0);
+    expect(render.find(TextField).length).toEqual(3);
+    expect(render.find(TextField).get(0).props.source).toEqual('id');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldA');
+    expect(render.find(TextField).get(2).props.source).toEqual('fieldB');
+  });
+
+  test('with custom fields', () => {
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      listFields: [
+        new Field('fieldC', {
+          id: 'http://schema.org/fieldC',
+          range: 'http://www.w3.org/2001/XMLSchema#string',
+          reference: null,
+          required: true,
+        }),
+      ],
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <List
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(1);
+    expect(render.find(TextField).length).toEqual(2);
+    expect(render.find(TextField).get(0).props.source).toEqual('id');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldC');
+  });
+});

--- a/src/Show.js
+++ b/src/Show.js
@@ -4,16 +4,39 @@ import {Show as BaseShow, SimpleShowLayout, TextField} from 'admin-on-rest';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+const resolveProps = props => {
+  const {options} = props;
+  const {fieldFactory: defaultFieldFactory, resource} = options;
+  const {
+    showFields: customFields,
+    readableFields: defaultFields,
+    showProps = {},
+  } = resource;
+  const {options: {fieldFactory: customFieldFactory} = {}} = showProps;
+
+  return {
+    ...props,
+    ...showProps,
+    options: {
+      ...options,
+      fieldFactory: customFieldFactory || defaultFieldFactory,
+      fields: customFields || defaultFields,
+    },
+  };
+};
+
 const Show = props => {
-  const {options: {api, fieldFactory, resource}} = props;
+  const {
+    addIdField,
+    options: {api, fieldFactory, fields, resource},
+  } = resolveProps(props);
 
   return (
     <BaseShow {...props}>
       <SimpleShowLayout>
-        <TextField source="id" />
-        {resource.readableFields.map(field =>
+        {addIdField && <TextField source="id" />}
+        {fields.map(field =>
           fieldFactory(field, {
-            action: 'show',
             api,
             resource,
           }),
@@ -23,11 +46,17 @@ const Show = props => {
   );
 };
 
+Show.defaultProps = {
+  addIdField: true,
+};
+
 Show.propTypes = {
+  addIdField: PropTypes.bool,
   options: PropTypes.shape({
     api: PropTypes.instanceOf(Api).isRequired,
     fieldFactory: PropTypes.func.isRequired,
     resource: PropTypes.instanceOf(Resource).isRequired,
+    showProps: PropTypes.object,
   }),
 };
 

--- a/src/Show.test.js
+++ b/src/Show.test.js
@@ -1,0 +1,169 @@
+import Api from '@api-platform/api-doc-parser/lib/Api';
+import Field from '@api-platform/api-doc-parser/lib/Field';
+import Resource from '@api-platform/api-doc-parser/lib/Resource';
+import {TextField} from 'admin-on-rest';
+import {shallow} from 'enzyme';
+import React from 'react';
+import fieldFactory from './fieldFactory';
+import Show from './Show';
+
+const entrypoint = 'http://entrypoint';
+
+const apiData = {
+  entrypoint,
+};
+
+const resourceData = {
+  name: 'user',
+  readableFields: [
+    new Field('fieldA', {
+      id: 'http://schema.org/fieldA',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+    new Field('fieldB', {
+      id: 'http://schema.org/fieldB',
+      range: 'http://www.w3.org/2001/XMLSchema#string',
+      reference: null,
+      required: true,
+    }),
+  ],
+  url: `${entrypoint}/users`,
+};
+
+describe('<Show />', () => {
+  test('without overrides', () => {
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(
+      resourceData.name,
+      resourceData.url,
+      resourceData,
+    );
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Show
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(2);
+    expect(render.find(TextField).length).toEqual(3);
+    expect(render.find(TextField).get(0).props.source).toEqual('id');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldA');
+    expect(render.find(TextField).get(2).props.source).toEqual('fieldB');
+  });
+
+  test('without adding ID', () => {
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      showProps: {
+        addIdField: false,
+      },
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Show
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(2);
+    expect(render.find(TextField).length).toEqual(2);
+    expect(render.find(TextField).get(0).props.source).toEqual('fieldA');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldB');
+  });
+
+  test('with custom fieldFactory', () => {
+    const customFieldFactory = jest.fn(fieldFactory);
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      showProps: {
+        options: {
+          fieldFactory: customFieldFactory,
+        },
+      },
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Show
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(customFieldFactory).toHaveBeenCalledTimes(2);
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(0);
+    expect(render.find(TextField).length).toEqual(3);
+    expect(render.find(TextField).get(0).props.source).toEqual('id');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldA');
+    expect(render.find(TextField).get(2).props.source).toEqual('fieldB');
+  });
+
+  test('with custom fields', () => {
+    const defaultFieldFactory = jest.fn(fieldFactory);
+
+    const resource = new Resource(resourceData.name, resourceData.url, {
+      ...resourceData,
+      showFields: [
+        new Field('fieldC', {
+          id: 'http://schema.org/fieldC',
+          range: 'http://www.w3.org/2001/XMLSchema#string',
+          reference: null,
+          required: true,
+        }),
+      ],
+    });
+
+    const api = new Api(apiData.entrypoint, {
+      ...apiData,
+      resources: [resource],
+    });
+
+    const render = shallow(
+      <Show
+        options={{
+          api,
+          fieldFactory: defaultFieldFactory,
+          resource,
+        }}
+      />,
+    );
+
+    expect(defaultFieldFactory).toHaveBeenCalledTimes(1);
+    expect(render.find(TextField).length).toEqual(2);
+    expect(render.find(TextField).get(0).props.source).toEqual('id');
+    expect(render.find(TextField).get(1).props.source).toEqual('fieldC');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,6 +1015,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1124,6 +1128,27 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
+
+cheerio@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash.assignin "^4.0.9"
+    lodash.bind "^4.1.4"
+    lodash.defaults "^4.0.1"
+    lodash.filter "^4.4.0"
+    lodash.flatten "^4.2.0"
+    lodash.foreach "^4.3.0"
+    lodash.map "^4.4.0"
+    lodash.merge "^4.4.0"
+    lodash.pick "^4.2.1"
+    lodash.reduce "^4.4.0"
+    lodash.reject "^4.4.0"
+    lodash.some "^4.4.0"
 
 chokidar@^1.6.1:
   version "1.7.0"
@@ -1268,6 +1293,19 @@ css-in-js-utils@^2.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -1391,6 +1429,41 @@ dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -1407,6 +1480,25 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+enzyme@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.9.1.tgz#07d5ce691241240fb817bf2c4b18d6e530240df6"
+  dependencies:
+    cheerio "^0.22.0"
+    function.prototype.name "^1.0.0"
+    is-subset "^0.1.1"
+    lodash "^4.17.4"
+    object-is "^1.0.1"
+    object.assign "^4.0.4"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.5.10"
+    uuid "^3.0.1"
+
 errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -1422,6 +1514,16 @@ error-ex@^1.2.0:
 es-abstract@^1.5.0, es-abstract@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-abstract@^1.6.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.1"
@@ -1877,9 +1979,17 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+function.prototype.name@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    is-callable "^1.1.3"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -2007,6 +2117,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2077,6 +2191,17 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -2314,6 +2439,10 @@ is-resolvable@^1.0.0:
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-symbol@^1.0.1:
   version "1.0.1"
@@ -2806,6 +2935,14 @@ lodash-es@^4.17.3, lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
+lodash.assignin@^4.0.9:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.bind@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -2814,9 +2951,25 @@ lodash.debounce@~4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
 lodash.defaultsdeep@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz#bec1024f85b1bd96cbea405b23c14ad6443a6f81"
+
+lodash.filter@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
 lodash.get@^4.4.2, lodash.get@~4.4.2:
   version "4.4.2"
@@ -2830,17 +2983,41 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
+lodash.map@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+
+lodash.merge@^4.4.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+
 lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.pick@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.pickby@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash.reduce@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
+lodash.reject@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
+
 lodash.set@~4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+
+lodash.some@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -3040,6 +3217,12 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -3056,9 +3239,31 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-keys@^1.0.8:
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -3066,6 +3271,15 @@ object.omit@^2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -3409,6 +3623,13 @@ react-router@~4.1.0:
     path-to-regexp "^1.5.3"
     prop-types "^15.5.4"
     warning "^3.0.0"
+
+react-test-renderer@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 react-transition-group@^1.2.1:
   version "1.2.1"
@@ -4070,6 +4291,10 @@ util-deprecate@~1.0.1:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.0.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 v8flags@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

With this PR, we can now:

* define our own component props.

```js
// ...

const resource = api.resources.find(({ name }) => name === 'users');

// Define number of items on "list" view for "users" resource.
resource.listProps = {
    perPage: 5,
};

// ...
```

* remove auto-added ID field in `List` and `Show` view.

```js
// ...

// Remove auto-generated ID on all resources.
api.resources.forEach(resource => {
    resource.listProps = {
        addIdField: false,
    };

    resource.showProps = {
        addIdField: false,
    };
});

// ...
```

* define a custom `inputFactory` / `fieldFactory` for a specified action on resource.

```js
import userListFieldFactory from './user-list-field-factory';

// ...

const resource = api.resources.find(({ name }) => name === 'users');

// Use a custom "fieldFactory" for "list" view.
resource.listProps = {
    options: {
        fieldFactory: userListFieldFactory,
    }
};

// ...
```

* define fields to use for a specified action on resource.

```js
// ...

const resource = api.resources.find(({ name }) => name === 'users');

// Show only name in "list" view.
resource.listField = [
    resource.fields.find(({ name }) => name === 'name'),
];

// ...
```