### PR TITLE
Add the ability to test "api-platform/admin" files with react-scripts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,16 +1,17 @@
 {
   "plugins": [
     "transform-react-jsx",
-    "transform-runtime"
+    [
+      "transform-runtime",
+      {
+        "polyfill": false,
+        "regenerator": true
+      }
+    ]
   ],
   "presets": [
-    ["es2015", { "loose": true, "modules": false }],
+    "es2015",
     "stage-0",
     "react"
-  ],
-  "env": {
-    "test": {
-      "plugins": [["transform-es2015-modules-commonjs", { "loose": true }]]
-    }
-  }
+  ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | -

When we tried to test a component that include `fetchHydra`, we had the following error:

```
 FAIL  src/my-component.test.js
  ● Test suite failed to run

    /srv/node_modules/@api-platform/admin/lib/hydra/fetchHydra.js:2
    import HttpError from 'admin-on-rest/lib/util/HttpError';
    ^^^^^^
    
    SyntaxError: Unexpected token import
      
      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/ScriptTransformer.js:289:17)
      at Object.<anonymous> (src/my-component.test.js.js:4:19)
      at Object.<anonymous> (src/my-component.test.js.test.js:3:19)
```

As `react-scripts` does not give the possibility to change `babel` or `webpack` configuration, I changed the `.babelrc` (see the [admin-on-rest babel configuration](https://github.com/marmelab/admin-on-rest/blob/master/.babelrc)).