### PR TITLE
Add ability to customize request body type

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -65,17 +65,12 @@ export const transformJsonLdDocumentToAORDocument = (
  */
 export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
   /**
-   * @param {string} resource
+   * @param {Object} resource
    * @param {Object} data
    *
    * @returns {Promise}
    */
   const convertAORDataToHydraData = (resource, data = {}) => {
-    resource = resources.find(({name}) => resource === name);
-    if (undefined === resource) {
-      return Promise.resolve(data);
-    }
-
     const fieldData = [];
     resource.fields.forEach(({name, normalizeData}) => {
       if (!(name in data) || undefined === normalizeData) {
@@ -99,6 +94,25 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
   };
 
   /**
+   * @param {Object} resource 
+   * @param {Object} data 
+   * 
+   * @returns {Promise}
+   */
+  const transformAORDataToRequestBody = (resource, data = {}) => {
+    resource = resources.find(({name}) => resource === name);
+    if (undefined === resource) {
+      return Promise.resolve(data);
+    }
+
+    return convertAORDataToHydraData(resource, data).then(data => {
+      return undefined === resource.encodeData
+        ? JSON.stringify(data)
+        : resource.encodeData(data);
+    });
+  };
+
+  /**
    * @param {string} type
    * @param {string} resource
    * @param {Object} params
@@ -108,9 +122,12 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
   const convertAORRequestToHydraRequest = (type, resource, params) => {
     switch (type) {
       case CREATE:
-        return convertAORDataToHydraData(resource, params.data).then(data => ({
+        return transformAORDataToRequestBody(
+          resource,
+          params.data,
+        ).then(body => ({
           options: {
-            body: JSON.stringify(data),
+            body,
             method: 'POST',
           },
           url: `${entrypoint}/${resource}`,
@@ -154,9 +171,12 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
         });
 
       case UPDATE:
-        return convertAORDataToHydraData(resource, params.data).then(data => ({
+        return transformAORDataToRequestBody(
+          resource,
+          params.data,
+        ).then(body => ({
           options: {
-            body: JSON.stringify(data),
+            body,
             method: 'PUT',
           },
           url: entrypoint + params.id,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

**Why?**

I've tried to create decorator of `fetchHydra` to handle additional API Endpoint which uses `multipart/form-data` content type as request body to send a file, but I've encountered a problem, which made me to copy whole `httpClient` from this package and add some logic. It is all because in `fetchApi` method of `httpClient` we first `convertAORRequestToHydraRequest` where simply `JSON.stringify()` is done, then use decorated `httpClient`.

I figured out, that if we're able to normalize all property fields, we could also serialize whole resource. It may be helpful not only for passing `FormData` object as request body but also gives ability to use custom object serializer.

Also please note that in `@api-platform/api-doc-parser` we already support sending body as `FormData`.

I'll create doc PR if you agree to this feature. 

In meantime this is a example usage while decorating `parseHydraDocumentation`:

```javascript
// assert 'image' field of 'resource' is ImageInput type and normalizeData on this field returns `File` object

resource.serializeData = (data) => {
  const body = new FormData();
  body.append('image', data.image);
  return body;
};
```
Then automatically when calling CREATE / UPDATE action resource is handled properly, even without additional configuration.