### PR TITLE
Update "admin-on-rest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@api-platform/api-doc-parser": "^0.3.2",
-    "admin-on-rest": "^1.4",
+    "admin-on-rest": "^1.4.1",
     "babel-runtime": "^6.23",
     "jsonld": "^0.4",
     "lodash.isplainobject": "^4.0.6",

--- a/src/List.test.js
+++ b/src/List.test.js
@@ -49,6 +49,8 @@ describe('<List />', () => {
 
     const render = shallow(
       <List
+        hasEdit={true}
+        hasShow={true}
         options={{
           api,
           fieldFactory: defaultFieldFactory,
@@ -81,6 +83,8 @@ describe('<List />', () => {
 
     const render = shallow(
       <List
+        hasEdit={true}
+        hasShow={true}
         options={{
           api,
           fieldFactory: defaultFieldFactory,
@@ -115,6 +119,8 @@ describe('<List />', () => {
 
     const render = shallow(
       <List
+        hasEdit={true}
+        hasShow={true}
         options={{
           api,
           fieldFactory: defaultFieldFactory,
@@ -153,6 +159,8 @@ describe('<List />', () => {
 
     const render = shallow(
       <List
+        hasEdit={true}
+        hasShow={true}
         options={{
           api,
           fieldFactory: defaultFieldFactory,

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,9 +42,9 @@ acorn@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
-admin-on-rest@^1.4:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/admin-on-rest/-/admin-on-rest-1.4.0.tgz#161d2c6ea76af031f295e2e4aca306012c9f4792"
+admin-on-rest@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/admin-on-rest/-/admin-on-rest-1.4.1.tgz#0a37f76b098fe15d8e8b01705f787d4f58bdf8a2"
   dependencies:
     babel-runtime "~6.26.0"
     inflection "~1.12.0"
@@ -67,7 +67,7 @@ admin-on-rest@^1.4:
     react-router-redux "~5.0.0-alpha.6"
     recompose "~0.25.0"
     redux "~3.7.2"
-    redux-form "~7.0.3"
+    redux-form "~7.1.1"
     redux-saga "~0.15.0"
     reselect "~3.0.0"
 
@@ -3734,13 +3734,13 @@ recompose@~0.25.0:
     hoist-non-react-statics "^2.3.1"
     symbol-observable "^1.0.4"
 
-redux-form@~7.0.3:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.0.4.tgz#2297b6bed40fda8bb58132e261ba0976fb4e530c"
+redux-form@~7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.1.2.tgz#6b0f25c57fd8130a05ce00f6435fe1b051f402af"
   dependencies:
     deep-equal "^1.0.1"
     es6-error "^4.0.0"
-    hoist-non-react-statics "^2.2.1"
+    hoist-non-react-statics "^2.3.1"
     invariant "^2.2.2"
     is-promise "^2.1.0"
     lodash "^4.17.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | 
| License       | MIT
| Doc PR        | -

Use version `1.4.1` of `admin-on-rest`. This version removes warning in Travis.
