### PR TITLE
Support embedded relations

### DIFF
--- a/src/hydra/hydraClient.test.js
+++ b/src/hydra/hydraClient.test.js
@@ -52,6 +52,19 @@ describe('map a json-ld document to an admin on rest compatible document', () =>
         jsonLdDocument.itemReviewed.id,
       );
     });
+
+    test('an AOR can be casted to a string, and this string is the IRI', () => {
+      expect(AORDocument.toString()).toBe('/reviews/327');
+    });
+
+    const AORDocumentDepth3 = transformJsonLdDocumentToAORDocument(3)(
+      jsonLdDocument,
+    );
+
+    test('embedded documents are transformed to AORDocument instancesn and can be casted to strings', () => {
+      expect(AORDocumentDepth3.itemReviewed.toString()).toBe('/books/2');
+      expect(AORDocumentDepth3.comment[0].toString()).toBe('/comments/1');
+    });
   });
 
   describe('transform the embedded document when called with a max depth of 2', () => {

--- a/src/hydra/hydraClient.test.js
+++ b/src/hydra/hydraClient.test.js
@@ -34,56 +34,37 @@ describe('map a json-ld document to an admin on rest compatible document', () =>
         dateCreated: '2017-04-27T00:00:00+00:00',
       },
     ],
+    aNestedObject: {
+      foo: 'bar',
+    },
   };
 
-  describe('transform only the main document when called with a max depth of 1', () => {
-    const AORDocument = transformJsonLdDocumentToAORDocument(1)(jsonLdDocument);
+  describe('transform the JSON-LD document in AOR document', () => {
+    const AORDocument = transformJsonLdDocumentToAORDocument(jsonLdDocument);
+
+    test('deep clone the original object', () => {
+      expect(AORDocument).not.toBe(jsonLdDocument);
+      expect(AORDocument.aNestedObject).not.toBe(jsonLdDocument.aNestedObject);
+    });
 
     test('add an id property equal to the original @id property', () => {
-      expect(AORDocument.id).toEqual(jsonLdDocument['@id']);
+      expect(AORDocument.id).toBe(jsonLdDocument['@id']);
     });
 
     test('preserve the previous id property value in a new originId property', () => {
-      expect(AORDocument.originId).toEqual(jsonLdDocument.id);
+      expect(AORDocument.originId).toBe(jsonLdDocument.id);
     });
 
-    test('do not alter the embedded document', () => {
-      expect(AORDocument.itemReviewed.id).toEqual(
-        jsonLdDocument.itemReviewed.id,
-      );
+    test('an AOR has a custom toString method', () => {
+      expect(AORDocument.toString()).toBe('[object /reviews/327]');
     });
 
-    test('an AOR can be casted to a string, and this string is the IRI', () => {
-      expect(AORDocument.toString()).toBe('/reviews/327');
+    test('transform embedded documents to their IRIs', () => {
+      expect(AORDocument.itemReviewed).toBe('/books/2');
     });
 
-    const AORDocumentDepth3 = transformJsonLdDocumentToAORDocument(3)(
-      jsonLdDocument,
-    );
-
-    test('embedded documents are transformed to AORDocument instancesn and can be casted to strings', () => {
-      expect(AORDocumentDepth3.itemReviewed.toString()).toBe('/books/2');
-      expect(AORDocumentDepth3.comment[0].toString()).toBe('/comments/1');
-    });
-  });
-
-  describe('transform the embedded document when called with a max depth of 2', () => {
-    const AORDocument = transformJsonLdDocumentToAORDocument(2)(jsonLdDocument);
-
-    test('add an id property on the embedded document equal to the @id property of the embedded document', () => {
-      expect(AORDocument.itemReviewed.id).toEqual(
-        AORDocument.itemReviewed['@id'],
-      );
-    });
-  });
-
-  describe('transform the embedded document collection when called with a max depth of 3', () => {
-    const AORDocument = transformJsonLdDocumentToAORDocument(3)(jsonLdDocument);
-
-    test('add an id property on each document of an embedded collection equal to the @id property', () => {
-      AORDocument.comment.forEach(comment => {
-        expect(comment.id).toEqual(comment['@id']);
-      });
+    test('transform arrays of embedded documents to their IRIs', () => {
+      expect(AORDocument.comment[0]).toBe('/comments/1');
     });
   });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, if the returned JSON-LD document contains [embedded relations](https://api-platform.com/docs/core/serialization/#embedding-relations), Admin isn't able to deal with it an throws an errors.

This PR let Admin find the `@id` of the nested document to retrieve it.