### PR TITLE
Fix singular DELETE

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -302,7 +302,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
           .then(data => ({data, total: response.json['hydra:totalItems']}));
 
       case DELETE:
-        return Promise.resolve(() => ({data: {}}));
+        return Promise.resolve({data: {}});
 
       default:
         return Promise.resolve(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/api-platform/admin/pull/99#issuecomment-396924502
| License       | MIT
| Doc PR        | --

Alternative for #99
Fixes error that occures in background (see dev console) after deleting single element.

Consistent with behaviour for `DELETE_MANY`:

Which is to return only `{data: {}}`, instead of function in Promise.
https://github.com/api-platform/admin/blob/a64e6e9dd06f0458e29973b6aa7552c49e1f5c0c/src/hydra/hydraClient.js#L339
