### PR TITLE
Do not alter relations when GET_ONE

### DIFF
--- a/src/InputGuesser.js
+++ b/src/InputGuesser.js
@@ -38,8 +38,11 @@ export const InputGuesserComponent = ({fields, resourceSchema, ...props}) => {
           reference={field.reference.name}
           source={field.name}
           validate={validate}
-          {...props}
-          allowEmpty>
+          format={inputValue =>
+            typeof inputValue === 'object' ? inputValue['@id'] : inputValue
+          }
+          allowEmpty
+          {...props}>
           <SelectInput optionText={getReferenceNameField(field.reference)} />
         </ReferenceInput>
       );
@@ -51,9 +54,16 @@ export const InputGuesserComponent = ({fields, resourceSchema, ...props}) => {
         label={field.name}
         reference={field.reference.name}
         source={field.name}
+        format={inputValue =>
+          Array.isArray(inputValue)
+            ? inputValue.map(value =>
+                typeof value === 'object' ? value['@id'] : value,
+              )
+            : null
+        }
         validate={validate}
-        {...props}
-        allowEmpty>
+        allowEmpty
+        {...props}>
         <SelectArrayInput optionText={getReferenceNameField(field.reference)} />
       </ReferenceArrayInput>
     );

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -67,7 +67,8 @@ describe('map a json-ld document to an admin on rest compatible document', () =>
     });
 
     test('transform arrays of embedded documents to their IRIs', () => {
-      expect(reactAdminDocument.comment[0]).toBe('/comments/1');
+      expect(reactAdminDocument.comment[0]['@id']).toBe('/comments/1');
+      expect(reactAdminDocument.comment[0]['id']).toBe(1);
     });
   });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | 

When a `GET_ONE` is performed the `hydraClient` automatically replace related entities by their `id`.
_Example :_ 
If the API return is : 
```
{
    "fieldLvl1":"dzadza",
    "linkedEntity":{
        "id": 1,
        "fieldLvl2":"dzadza",
    }
}
```

The client will return : 
```
{
    "fieldLvl1":"dzadza",
    "linkedEntity": 1
}
```

This object is then passed to the Edit component as `record` props. So if an input with `linkedEntity.fieldLvl2` is declared, it will not get his expected value.