### PR TITLE
Add icon props to Resource + Test

### DIFF
--- a/src/resourceFactory.js
+++ b/src/resourceFactory.js
@@ -16,6 +16,7 @@ export default (
     create = Create,
     edit = Edit,
     list = List,
+    icon,
     name,
     props,
     show = Show,
@@ -28,6 +29,7 @@ export default (
       key={name}
       list={list}
       name={name}
+      icon={icon}
       options={{
         api,
         fieldFactory,

--- a/src/resourceFactory.test.js
+++ b/src/resourceFactory.test.js
@@ -34,7 +34,7 @@ describe('makes Resource component', () => {
     test('have proper name prop set', () => {
       expect(resourceComponent.props.name).toEqual(resource.name);
     });
-    
+
     test('have proper icon prop set', () => {
       expect(resourceComponent.props.icon).toEqual(resource.icon);
     });

--- a/src/resourceFactory.test.js
+++ b/src/resourceFactory.test.js
@@ -34,6 +34,10 @@ describe('makes Resource component', () => {
     test('have proper name prop set', () => {
       expect(resourceComponent.props.name).toEqual(resource.name);
     });
+    
+    test('have proper icon prop set', () => {
+      expect(resourceComponent.props.icon).toEqual(resource.icon);
+    });
 
     test('have default actions: create, edit, list, show set', () => {
       expect(resourceComponent.props.create).toBeInstanceOf(Function);
@@ -87,6 +91,21 @@ describe('makes Resource component', () => {
       );
 
       expect(resourceComponent.props.create).toEqual(customCreate);
+    });
+
+    test('have custom icon action', () => {
+      const customIcon = jest.fn();
+      const resourceComponent = resourceFactory(
+        Object.assign({}, resource, {
+          icon: customIcon,
+        }),
+        api,
+        fieldFactory,
+        inputFactory,
+        parameterFactory,
+      );
+
+      expect(resourceComponent.props.icon).toEqual(customIcon);
     });
 
     test('have custom list action', () => {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #127
| License       | MIT
| Doc PR        | api-platform/doc#674

Now custom icons can be defined in the admin component of the api-platform