### PR TITLE
Quick fix for issue #132 : Error when deleting a resource

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -320,7 +320,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
           .then(data => ({data, total: response.json['hydra:totalItems']}));
 
       case DELETE:
-        return Promise.resolve({data: {}});
+        return Promise.resolve({data: {id: null}});
 
       default:
         return Promise.resolve(
@@ -353,7 +353,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
       case DELETE_MANY:
         return Promise.all(
           params.ids.map(id => fetchApi(DELETE, resource, {id})),
-        ).then(responses => ({data: {}}));
+        ).then(responses => ({data: []}));
 
       default:
         return convertReactAdminRequestToHydraRequest(type, resource, params)


### PR DESCRIPTION
+ react-admin should be fixed instead, for long-term fix.
+ react-admin should not expect a content in the response after a delete or delete_many

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #132
| License       | MIT
| Doc PR        | 
