### PR TITLE
Add a filter function to remove fields from the list pages

### DIFF
--- a/src/AdminBuilder.js
+++ b/src/AdminBuilder.js
@@ -30,6 +30,7 @@ const AdminBuilder = props => {
     parameterFactory,
     title = api.title,
     resources = api.resources.filter(({deprecated}) => !deprecated),
+    listFieldFilter,
   } = props;
 
   return (
@@ -41,6 +42,7 @@ const AdminBuilder = props => {
           fieldFactory,
           inputFactory,
           parameterFactory,
+          listFieldFilter,
         ),
       )}
     </Admin>

--- a/src/List.js
+++ b/src/List.js
@@ -23,6 +23,7 @@ const resolveProps = props => {
   const {
     fieldFactory: defaultFieldFactory,
     parameterFactory,
+    listFieldFilter,
     resource,
   } = options;
   const {
@@ -42,6 +43,7 @@ const resolveProps = props => {
       fieldFactory: customFieldFactory || defaultFieldFactory,
       parameterFactory: parameterFactory,
       parameters: resource.parameters,
+      listFieldFilter: listFieldFilter,
     },
   };
 };
@@ -56,6 +58,7 @@ const List = props => {
       fields,
       parameterFactory,
       parameters,
+      listFieldFilter,
       resource,
     },
     addIdField = false === hasIdentifier(fields),
@@ -72,12 +75,14 @@ const List = props => {
             sortable={isFieldSortable({name: 'id'}, resource)}
           />
         )}
-        {fields.map(field =>
-          fieldFactory(field, {
-            api,
-            resource,
-          }),
-        )}
+        {fields
+          .filter(field => !listFieldFilter || listFieldFilter(resource, field))
+          .map(field =>
+            fieldFactory(field, {
+              api,
+              resource,
+            }),
+          )}
         {hasShow && <ShowButton />}
         {hasEdit && <EditButton />}
       </Datagrid>

--- a/src/resourceFactory.js
+++ b/src/resourceFactory.js
@@ -11,6 +11,7 @@ export default (
   fieldFactory,
   inputFactory,
   parameterFactory,
+  listFieldFilter,
 ) => {
   const {
     create = Create,
@@ -35,6 +36,7 @@ export default (
         fieldFactory,
         inputFactory,
         parameterFactory,
+        listFieldFilter,
         resource,
       }}
       show={show}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I need to remove some fields from the List pages. With this commit I introduce a filter function which can be used to select what needs be shown and what hidden from the List component.

The way I use the new function is something like this:
```

const hiddenFromList = [
  { entity: "people", fields: [ "address", "friends", ]},
  { entity: "books", fields: [ "reviews", ]},
];

const listFieldFilter = (resource, field) => {
  const hiddenResource = hiddenFromList.find(hidden => hidden.entity === resource.name);
  return !hiddenResource || !hiddenResource.fields.includes(field.name);
};

export default props => (
    <HydraAdmin
       ... // here the apiDocumentationParser, authProvider, entrypoint, etc
        listFieldFilter={listFieldFilter}
    />
);
```