### PR TITLE
Add filter/sort/pagination to GET_MANY_REFERENCE react-admin mapping

### DIFF
--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -193,7 +193,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
         });
 
       case GET_LIST:
-      case GET_MANY_REFERENCE:
+      case GET_MANY_REFERENCE: {
         const {
           pagination: {page, perPage},
           sort: {field, order},
@@ -227,6 +227,7 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
           options: {},
           url: collectionUrl,
         });
+      }
 
       case GET_ONE:
         return Promise.resolve({

--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -192,7 +192,8 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
           url: itemUrl,
         });
 
-      case GET_LIST: {
+      case GET_LIST:
+      case GET_MANY_REFERENCE:
         const {
           pagination: {page, perPage},
           sort: {field, order},
@@ -218,16 +219,10 @@ export default ({entrypoint, resources = []}, httpClient = fetchHydra) => {
           });
         }
 
-        return Promise.resolve({
-          options: {},
-          url: collectionUrl,
-        });
-      }
-
-      case GET_MANY_REFERENCE:
-        if (params.target) {
+        if (type === GET_MANY_REFERENCE && params.target) {
           collectionUrl.searchParams.set(params.target, params.id);
         }
+
         return Promise.resolve({
           options: {},
           url: collectionUrl,

--- a/src/hydra/hydraClient.test.js
+++ b/src/hydra/hydraClient.test.js
@@ -1,4 +1,10 @@
-import {DELETE, DELETE_MANY, GET_LIST, GET_MANY} from 'react-admin';
+import {
+  DELETE,
+  DELETE_MANY,
+  GET_LIST,
+  GET_MANY,
+  GET_MANY_REFERENCE,
+} from 'react-admin';
 import hydraClient, {
   transformJsonLdDocumentToReactAdminDocument,
 } from './hydraClient';
@@ -135,6 +141,37 @@ describe('fetch data from an hydra api', () => {
     ).then(response => {
       expect(response.data[0].id).toEqual('/books/3');
       expect(response.data[1].id).toEqual('/books/5');
+    });
+  });
+
+  test('fetch a get_many_reference resource', async () => {
+    const mockHttpClient = jest.fn();
+    mockHttpClient.mockReturnValue(
+      Promise.resolve({
+        json: {
+          'hydra:member': [{'@id': 'books/5'}],
+        },
+      }),
+    );
+
+    await hydraClient({entrypoint: '/api'}, mockHttpClient)(
+      GET_MANY_REFERENCE,
+      'books',
+      {
+        target: 'author',
+        id: 'string',
+        pagination: {page: 2},
+        sort: {field: 'id', order: 'ASC'},
+        filter: {
+          is_published: 1,
+        },
+      },
+    ).then(response => {
+      expect(mockHttpClient.mock.calls[0][0].href).toBe(
+        `${
+          window.location.origin
+        }/api/books?order%5Bid%5D=ASC&page=2&is_published=1&author=string`,
+      );
     });
   });
 


### PR DESCRIPTION
These are supported by ReferenceManyField and ReferenceArrayInput in react-admin

Sorry I'm not sure if this qualifies as a bug fix or new feature (a bit of both?)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  #162
| License       | MIT
| Doc PR        | n/a

*Please update this template with something that matches your PR*
