### PR TITLE
Fix edit and delete buttons

### DIFF
--- a/src/EditGuesser.js
+++ b/src/EditGuesser.js
@@ -6,10 +6,10 @@ import WithReactAdminQuery from './withReactAdminQuery';
 
 // useful for testing (we don't need Query)
 const EditGuesserComponent = props => {
-  const {children, fields} = props;
+  const {children, fields, resourceSchema, ...filteredProps} = props;
 
   return (
-    <Edit {...props}>
+    <Edit {...filteredProps} undoable={false}>
       <SimpleForm>
         {children}
         {fields.map(field => (

--- a/src/FilterGuesser.js
+++ b/src/FilterGuesser.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import {Filter, Loading, Query} from 'react-admin';
-import {getResource} from './docsUtils';
+import {Filter} from 'react-admin';
 import InputGuesser from './InputGuesser';
+import WithReactAdminQuery from './withReactAdminQuery';
 import {getFiltersParametersFromResourceSchema} from './docsUtils';
 
-class Filters extends React.Component {
+class FilterGuesserComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -28,18 +28,11 @@ class Filters extends React.Component {
   }
 
   render() {
-    const {
-      resourceSchema: resource,
-      fields: allowedFieldNames,
-      hasEdit,
-      hasShow,
-      ...props
-    } = this.props;
-
     if (!this.state.filtersParameters.length) {
       return null;
     }
 
+    const {resourceSchema, fields, hasShow, hasEdit, ...props} = this.props;
     return (
       <Filter {...props}>
         {this.state.filtersParameters.map(filter => (
@@ -54,37 +47,8 @@ class Filters extends React.Component {
   }
 }
 
-const FilterGuesser = props => {
-  const {resource: resourceName} = props;
-  return (
-    <Query type="INTROSPECT">
-      {({data: api, loading, error}) => {
-        if (loading) {
-          return <Loading />;
-        }
-
-        if (error) {
-          console.error(error);
-          return <div>Error while reading the API schema</div>;
-        }
-
-        const resourceSchema = getResource(api.resources, resourceName);
-
-        if (!resourceSchema || !resourceSchema.fields) {
-          console.error(
-            `Resource ${resourceName} not present inside api description`,
-          );
-          return (
-            <div>
-              Resource ${resourceName} not present inside api description
-            </div>
-          );
-        }
-
-        return <Filters resourceSchema={resourceSchema} {...props} />;
-      }}
-    </Query>
-  );
-};
+const FilterGuesser = props => (
+  <WithReactAdminQuery component={FilterGuesserComponent} {...props} />
+);
 
 export default FilterGuesser;

--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -1,26 +1,15 @@
 import React, {Children} from 'react';
 import PropTypes from 'prop-types';
-import {
-  Datagrid,
-  List,
-  Query,
-  EditButton,
-  ShowButton,
-  Loading,
-} from 'react-admin';
-import {existsAsChild, getResource} from './docsUtils';
+import {Datagrid, List, EditButton, ShowButton} from 'react-admin';
+import {getOrderParametersFromResourceSchema} from './docsUtils';
 import FieldGuesser from './FieldGuesser';
 import FilterGuesser from './FilterGuesser';
-import {getOrderParametersFromResourceSchema} from './docsUtils';
+import WithReactAdminQuery from './withReactAdminQuery';
 
-const getFields = (
-  {fields},
-  allowedFieldNames = fields.map(defaultField => defaultField.name),
-) => fields.filter(({name}) => allowedFieldNames.includes(name));
-
-class ResourcesList extends React.Component {
+class ListGuesserComponent extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       orderParameters: this.props.resourceSchema
         ? getOrderParametersFromResourceSchema(this.props.resourceSchema)
@@ -29,31 +18,22 @@ class ResourcesList extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.state.orderParameters.length) {
-      this.props.resourceSchema.getParameters().then(parameters => {
-        this.setState({
-          orderParameters: getOrderParametersFromResourceSchema({
-            ...this.props.resourceSchema,
-            parameters,
-          }),
-        });
-      });
+    if (this.state.orderParameters.length) {
+      return;
     }
+
+    this.props.resourceSchema.getParameters().then(() => {
+      this.setState({
+        orderParameters: getOrderParametersFromResourceSchema(
+          this.props.resourceSchema,
+        ),
+      });
+    });
   }
 
   render() {
-    const {
-      resourceSchema: resource,
-      fields: allowedFieldNames,
-      ...props
-    } = this.props;
-
+    const {resourceSchema, fields, hasShow, hasEdit, ...props} = this.props;
     const children = Children.toArray(props.children);
-
-    const fields = getFields(resource, allowedFieldNames).filter(
-      existsAsChild(children),
-    );
-
     return (
       <List {...props}>
         <Datagrid>
@@ -65,47 +45,17 @@ class ResourcesList extends React.Component {
               sortable={this.state.orderParameters.includes(field.name)}
             />
           ))}
-          {props.hasShow && <ShowButton />}
-          {props.hasEdit && <EditButton />}
+          {hasShow && <ShowButton />}
+          {hasEdit && <EditButton />}
         </Datagrid>
       </List>
     );
   }
 }
 
-const ListGuesser = props => {
-  const {resource: resourceName} = props;
-
-  return (
-    <Query type="INTROSPECT">
-      {({data: api, loading, error}) => {
-        if (loading) {
-          return <Loading />;
-        }
-
-        if (error) {
-          console.error(error);
-          return <div>Error while reading the API schema</div>;
-        }
-
-        const resourceSchema = getResource(api.resources, resourceName);
-
-        if (!resourceSchema || !resourceSchema.fields) {
-          console.error(
-            `Resource ${resourceName} not present inside api description`,
-          );
-          return (
-            <div>
-              Resource ${resourceName} not present inside api description
-            </div>
-          );
-        }
-
-        return <ResourcesList resourceSchema={resourceSchema} {...props} />;
-      }}
-    </Query>
-  );
-};
+const ListGuesser = props => (
+  <WithReactAdminQuery component={ListGuesserComponent} {...props} />
+);
 
 export default ListGuesser;
 

--- a/src/hydra/hydraClient.js
+++ b/src/hydra/hydraClient.js
@@ -165,11 +165,9 @@ export default (entrypoint, httpClient = fetchHydra) => {
       return Promise.resolve(data);
     }
 
-    return convertReactAdminDataToHydraData(resource, data).then(data => {
-      return undefined === resource.encodeData
-        ? JSON.stringify(data)
-        : resource.encodeData(data);
-    });
+    return convertReactAdminDataToHydraData(resource, data).then(data =>
+      JSON.stringify(data),
+    );
   };
 
   /**

--- a/src/withReactAdminQuery.js
+++ b/src/withReactAdminQuery.js
@@ -5,10 +5,6 @@ import {existsAsChild} from './docsUtils';
 const withReactAdminQuery = ({component: Component, ...props}) => (
   <Query type="INTROSPECT" resource={props.ressource}>
     {({data, loading, error}) => {
-      if (data == null) {
-        return null;
-      }
-
       if (loading) {
         return <Loading />;
       }
@@ -16,6 +12,10 @@ const withReactAdminQuery = ({component: Component, ...props}) => (
       if (error) {
         console.error(error);
         return <div>Error while reading the API schema</div>;
+      }
+
+      if (data == null) {
+        return null;
       }
 
       const resourceSchema = data.resources.find(
@@ -41,6 +41,7 @@ const withReactAdminQuery = ({component: Component, ...props}) => (
         <Component
           data={data}
           resource={props.ressource}
+          resourceSchema={resourceSchema}
           fields={fields}
           {...props}
         />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #214
| License       | MIT
| Doc PR        | n/a

Setting `undoable=false` fixes the issue... but disables the nice "undo" feature.

The problem seems to be a race condition between the `LIST` and the `UPDATE` operations. Whe `undoable` is enabled:

1. the `LIST` request is sent
2. The `UPDATE` request is sent with a delay
3. The result of `LIST` doesn't dispatch the function wrapped in `<Query>` as it should, and the loading screen never disappears.

@fzaninotto do you have an idea of how we can fix this?

Thanks to @mauchede for finding the underlying issue.