### PR TITLE
Render login page on unauthorized

### DIFF
--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -22,14 +22,14 @@ export const AdminGuesserComponent = (
     );
   }
 
-  if (error) {
+  if (error && data) {
     if ('production' === process.env.NODE_ENV) {
       console.error(error);
     }
     return <div>Error while reading the API schema</div>;
   }
 
-  if (!children) {
+  if (!children && data) {
     const resources = includeDeprecated
       ? data.resources
       : data.resources.filter(r => !r.deprecated);

--- a/src/AdminGuesser.test.js
+++ b/src/AdminGuesser.test.js
@@ -14,7 +14,11 @@ describe('<AdminGuesser />', () => {
       <Provider store={store}>
         {AdminGuesserComponent(
           {},
-          {error: 'Failed to fetch documentation', loading: false},
+          {
+            error: 'Failed to fetch documentation',
+            data: {resources},
+            loading: false,
+          },
         )}
       </Provider>,
     );
@@ -36,6 +40,29 @@ describe('<AdminGuesser />', () => {
     const tree = renderer.render(
       <Provider store={store}>
         {AdminGuesserComponent({}, {data: {resources}, loading: false})}
+      </Provider>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders without data', () => {
+    const tree = renderer.render(
+      <Provider store={store}>
+        {AdminGuesserComponent({}, {loading: false})}
+      </Provider>,
+    );
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders errors without data', () => {
+    const tree = renderer.render(
+      <Provider store={store}>
+        {AdminGuesserComponent(
+          {},
+          {error: 'Failed to fetch documentation', loading: false},
+        )}
       </Provider>,
     );
 

--- a/src/__snapshots__/AdminGuesser.test.js.snap
+++ b/src/__snapshots__/AdminGuesser.test.js.snap
@@ -6,6 +6,16 @@ exports[`<AdminGuesser /> renders errors 1`] = `
 </div>
 `;
 
+exports[`<AdminGuesser /> renders errors without data 1`] = `
+<withContext(CoreAdminBase)
+  appLayout={[Function]}
+  catchAll={[Function]}
+  loading={[Function]}
+  loginPage={[Function]}
+  logoutButton={[Function]}
+/>
+`;
+
 exports[`<AdminGuesser /> renders loading 1`] = `
 <Connect(TranslationProviderView)>
   <WithStyles(translate(Loading)) />
@@ -24,4 +34,14 @@ exports[`<AdminGuesser /> renders without custom resources 1`] = `
     name="books"
   />
 </withContext(CoreAdminBase)>
+`;
+
+exports[`<AdminGuesser /> renders without data 1`] = `
+<withContext(CoreAdminBase)
+  appLayout={[Function]}
+  catchAll={[Function]}
+  loading={[Function]}
+  loginPage={[Function]}
+  logoutButton={[Function]}
+/>
 `;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #235
| License       | MIT
| Doc PR        | NA

This PR fix 2 problems:
* Fix `Error while reading the API schema` when unauthorized
* Fix blank login page when no custom resources are provided, on the browser's console: `TypeError: data is null`
