### PR TITLE
Inject api document parser

### DIFF
--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -10,7 +10,7 @@ import {
 } from 'react-admin';
 import isPlainObject from 'lodash.isplainobject';
 import fetchHydra from './fetchHydra';
-import apiDocumentationParser from '@api-platform/api-doc-parser/lib/hydra/parseHydraDocumentation';
+import parseHydraDocumentation from '@api-platform/api-doc-parser/lib/hydra/parseHydraDocumentation';
 
 class ReactAdminDocument {
   constructor(obj) {
@@ -112,7 +112,11 @@ export const transformJsonLdDocumentToReactAdminDocument = (
  * GET_ONE  => GET http://my.api.url/posts/123
  * UPDATE   => PUT http://my.api.url/posts/123
  */
-export default (entrypoint, httpClient = fetchHydra) => {
+export default (
+  entrypoint,
+  httpClient = fetchHydra,
+  apiDocumentationParser = parseHydraDocumentation,
+) => {
   let apiSchema;
 
   /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #185
| License       | MIT
| Doc PR        | api-platform/docs#919

This PR allow to inject custom api document parser that has authorization key in headers before sending the request
