### PR TITLE
Allow to disable filters

### DIFF
--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -63,7 +63,7 @@ const ListGuesser = props => (
 ListGuesser.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   resource: PropTypes.string.isRequired,
-  filters: PropTypes.object.isRequired,
+  filters: PropTypes.element,
 };
 
 ListGuesser.defaultProps = {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | NA

1. This change allow us to disable filters:
```
<ListGuesser {...props}  filters={null}>
    <FieldGuesser source='test' />
  </ListGuesser>
```
2. We can't simply ommit `filters` property, because it has default value on `ListGuesser`
3. `filters` property is not required for `List`
