### PR TITLE
restore resource.encodeData

### DIFF
--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -170,7 +170,9 @@ export default (
     }
 
     return convertReactAdminDataToHydraData(resource, data).then(data =>
-      JSON.stringify(data),
+      undefined === resource.encodeData
+        ? JSON.stringify(data)
+        : resource.encodeData(data),
     );
   };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #238 
| License       | MIT
| Doc PR        | 

Restore usage of resource.encodeData to avoid breaking existing apps (at least for those who follow API Platform examples).

Usage of encodeData is needed to send files to API which expects multipart FormData.

Really blocking to update v0.6.3 to v1.x.x