### PR TITLE
Fix nested search filters and search filter for collection

### DIFF
--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -217,19 +217,31 @@ export default (
         if (page) collectionUrl.searchParams.set('page', page);
         if (perPage) collectionUrl.searchParams.set('perPage', perPage);
         if (params.filter) {
-          Object.keys(params.filter).forEach(key => {
-            const filterValue = params.filter[key];
+          const buildFilterParams = (key, nestedFilter, rootKey) => {
+            const filterValue = nestedFilter[key];
+
+            if (Array.isArray(filterValue)) {
+              filterValue.forEach((arrayFilterValue, index) => {
+                collectionUrl.searchParams.set(
+                  `${rootKey}[${index}]`,
+                  arrayFilterValue,
+                );
+              });
+              return;
+            }
+
             if (!isPlainObject(filterValue)) {
-              collectionUrl.searchParams.set(key, params.filter[key]);
+              collectionUrl.searchParams.set(rootKey, filterValue);
               return;
             }
 
             Object.keys(filterValue).forEach(subKey => {
-              collectionUrl.searchParams.set(
-                `${key}[${subKey}]`,
-                filterValue[subKey],
-              );
+              buildFilterParams(subKey, filterValue, `${rootKey}.${subKey}`);
             });
+          };
+
+          Object.keys(params.filter).forEach(key => {
+            buildFilterParams(key, params.filter, key);
           });
         }
 

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -1,6 +1,9 @@
-import {transformJsonLdDocumentToReactAdminDocument} from './dataProvider';
+import dataProvider, {
+  transformJsonLdDocumentToReactAdminDocument,
+} from './dataProvider';
+import {GET_LIST} from 'react-admin';
 
-describe('map a json-ld document to an admin on rest compatible document', () => {
+describe('Transform a JSON-LD document to a React Admin compatible document', () => {
   const JSON_LD_DOCUMENT = {
     '@id': '/reviews/327',
     id: 327,
@@ -38,36 +41,73 @@ describe('map a json-ld document to an admin on rest compatible document', () =>
     },
   };
 
-  describe('transform the JSON-LD document in React Admin document', () => {
-    const reactAdminDocument = transformJsonLdDocumentToReactAdminDocument(
-      JSON_LD_DOCUMENT,
+  const reactAdminDocument = transformJsonLdDocumentToReactAdminDocument(
+    JSON_LD_DOCUMENT,
+  );
+
+  test('deep clone the original object', () => {
+    expect(reactAdminDocument).not.toBe(JSON_LD_DOCUMENT);
+    expect(reactAdminDocument.aNestedObject).not.toBe(
+      JSON_LD_DOCUMENT.aNestedObject,
     );
+  });
 
-    test('deep clone the original object', () => {
-      expect(reactAdminDocument).not.toBe(JSON_LD_DOCUMENT);
-      expect(reactAdminDocument.aNestedObject).not.toBe(
-        JSON_LD_DOCUMENT.aNestedObject,
+  test('add an id property equal to the original @id property', () => {
+    expect(reactAdminDocument.id).toBe(JSON_LD_DOCUMENT['@id']);
+  });
+
+  test('preserve the previous id property value in a new originId property', () => {
+    expect(reactAdminDocument.originId).toBe(JSON_LD_DOCUMENT.id);
+  });
+
+  test('an React Admin has a custom toString method', () => {
+    expect(reactAdminDocument.toString()).toBe('[object /reviews/327]');
+  });
+
+  test('transform embedded documents to their IRIs', () => {
+    expect(reactAdminDocument.itemReviewed).toBe('/books/2');
+  });
+
+  test('transform arrays of embedded documents to their IRIs', () => {
+    expect(reactAdminDocument.comment[0]).toBe('/comments/1');
+  });
+});
+
+describe('Transform a React Admin request to an Hydra request', () => {
+  const mockFetchHydra = jest.fn();
+  mockFetchHydra.mockReturnValue({
+    json: {'hydra:member': [], 'hydra:totalItems': 3},
+  });
+  const fetchApi = dataProvider('entrypoint', mockFetchHydra);
+
+  test('React Admin get list with filter parameters', () => {
+    return fetchApi(GET_LIST, 'resource', {
+      pagination: {},
+      sort: {},
+      filter: {
+        simple: 'foo',
+        nested: {param: 'bar'},
+        sub_nested: {sub: {param: true}},
+        array: ['/iri/1', '/iri/2'],
+        nested_array: {nested: ['/nested_iri/1', '/nested_iri/2']},
+      },
+    }).then(() => {
+      const searchParams = Array.from(
+        mockFetchHydra.mock.calls[0][0].searchParams.entries(),
       );
-    });
-
-    test('add an id property equal to the original @id property', () => {
-      expect(reactAdminDocument.id).toBe(JSON_LD_DOCUMENT['@id']);
-    });
-
-    test('preserve the previous id property value in a new originId property', () => {
-      expect(reactAdminDocument.originId).toBe(JSON_LD_DOCUMENT.id);
-    });
-
-    test('an React Admin has a custom toString method', () => {
-      expect(reactAdminDocument.toString()).toBe('[object /reviews/327]');
-    });
-
-    test('transform embedded documents to their IRIs', () => {
-      expect(reactAdminDocument.itemReviewed).toBe('/books/2');
-    });
-
-    test('transform arrays of embedded documents to their IRIs', () => {
-      expect(reactAdminDocument.comment[0]).toBe('/comments/1');
+      expect(searchParams[0]).toEqual(['simple', 'foo']);
+      expect(searchParams[1]).toEqual(['nested.param', 'bar']);
+      expect(searchParams[2]).toEqual(['sub_nested.sub.param', 'true']);
+      expect(searchParams[3]).toEqual(['array[0]', '/iri/1']);
+      expect(searchParams[4]).toEqual(['array[1]', '/iri/2']);
+      expect(searchParams[5]).toEqual([
+        'nested_array.nested[0]',
+        '/nested_iri/1',
+      ]);
+      expect(searchParams[6]).toEqual([
+        'nested_array.nested[1]',
+        '/nested_iri/2',
+      ]);
     });
   });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #180, fixes #110
| License       | MIT
| Doc PR        |

Allow to traverse an infinite depth of nested search parameters and handle correctly searching in collection.