### PR TITLE
check for the value to be defined before checking the position of the…

### DIFF
--- a/src/InputGuesser.js
+++ b/src/InputGuesser.js
@@ -63,7 +63,9 @@ export const InputGuesserComponent = ({fields, resourceSchema, ...props}) => {
     const prefix = `/${props.resource}/`;
 
     props.format = value => {
-      return value && 0 === value.indexOf(prefix) ? value.substr(prefix.length) : value;
+      return value && 0 === value.indexOf(prefix)
+        ? value.substr(prefix.length)
+        : value;
     };
 
     props.parse = value => {

--- a/src/InputGuesser.js
+++ b/src/InputGuesser.js
@@ -63,7 +63,7 @@ export const InputGuesserComponent = ({fields, resourceSchema, ...props}) => {
     const prefix = `/${props.resource}/`;
 
     props.format = value => {
-      return 0 === value.indexOf(prefix) ? value.substr(prefix.length) : value;
+      return value && 0 === value.indexOf(prefix) ? value.substr(prefix.length) : value;
     };
 
     props.parse = value => {


### PR DESCRIPTION
… prefix

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #243
| License       | MIT
| Doc PR        | -

Sometimes the identifier may be null. When the value is not defined, using `indexOf` causes a crash.

This pull request add a check to ensure the value is defined before searching for the resource prefix.