### PR TITLE
Use reabable and writable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+* Use readable and writable fields instead of fields
+
 ## 2.0.0
 
 * Compatibility with react-admin 3

--- a/src/CreateGuesser.js
+++ b/src/CreateGuesser.js
@@ -26,6 +26,8 @@ const displayOverrideCode = (schema, fields) => {
 
 export const IntrospectedCreateGuesser = ({
   fields,
+  readableFields,
+  writableFields,
   schema,
   schemaAnalyzer,
   children,
@@ -33,10 +35,10 @@ export const IntrospectedCreateGuesser = ({
 }) => {
   let inputChildren = children;
   if (!inputChildren) {
-    inputChildren = fields.map(field => (
+    inputChildren = writableFields.map(field => (
       <InputGuesser key={field.name} source={field.name} />
     ));
-    displayOverrideCode(schema, fields);
+    displayOverrideCode(schema, writableFields);
   }
 
   return (

--- a/src/EditGuesser.js
+++ b/src/EditGuesser.js
@@ -25,18 +25,20 @@ const displayOverrideCode = (schema, fields) => {
 };
 
 export const IntrospectedEditGuesser = ({
-  children,
   fields,
-  schemaAnalyzer,
+  readableFields,
+  writableFields,
   schema,
+  schemaAnalyzer,
+  children,
   ...props
 }) => {
   let inputChildren = children;
   if (!inputChildren) {
-    inputChildren = fields.map(field => (
+    inputChildren = writableFields.map(field => (
       <InputGuesser key={field.name} source={field.name} />
     ));
-    displayOverrideCode(schema, fields);
+    displayOverrideCode(schema, writableFields);
   }
 
   return (

--- a/src/FieldGuesser.js
+++ b/src/FieldGuesser.js
@@ -75,6 +75,8 @@ const renderField = (field, schemaAnalyzer, props) => {
 
 export const IntrospectedFieldGuesser = ({
   fields,
+  readableFields,
+  writableFields,
   schema,
   schemaAnalyzer,
   ...props

--- a/src/FilterGuesser.js
+++ b/src/FilterGuesser.js
@@ -4,8 +4,10 @@ import InputGuesser from './InputGuesser';
 import Introspecter from './Introspecter';
 
 export const IntrospectedFilterGuesser = ({
-  schema,
   fields,
+  readableFields,
+  writableFields,
+  schema,
   schemaAnalyzer,
   hasShow,
   hasEdit,

--- a/src/InputGuesser.js
+++ b/src/InputGuesser.js
@@ -18,6 +18,8 @@ import Introspecter from './Introspecter';
 
 export const IntrospectedInputGuesser = ({
   fields,
+  readableFields,
+  writableFields,
   schema,
   schemaAnalyzer,
   ...props

--- a/src/Introspecter.js
+++ b/src/Introspecter.js
@@ -31,7 +31,12 @@ const ResourcesIntrospecter = ({
 
   const schema = resources.find(r => r.name === resource);
 
-  if (!schema || !schema.fields) {
+  if (
+    !schema ||
+    !schema.fields ||
+    !schema.readableFields ||
+    !schema.writableFields
+  ) {
     if ('production' === process.env.NODE_ENV) {
       console.error(`Resource ${resource} not present inside API description`);
     }
@@ -42,6 +47,12 @@ const ResourcesIntrospecter = ({
   const fields = includeDeprecated
     ? schema.fields
     : schema.fields.filter(({ deprecated }) => !deprecated);
+  const readableFields = includeDeprecated
+    ? schema.readableFields
+    : schema.readableFields.filter(({ deprecated }) => !deprecated);
+  const writableFields = includeDeprecated
+    ? schema.writableFields
+    : schema.writableFields.filter(({ deprecated }) => !deprecated);
 
   return (
     <Component
@@ -49,6 +60,8 @@ const ResourcesIntrospecter = ({
       resource={resource}
       schema={schema}
       fields={fields}
+      readableFields={readableFields}
+      writableFields={writableFields}
       {...rest}
     />
   );

--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -26,10 +26,12 @@ const displayOverrideCode = (schema, fields) => {
 };
 
 export const IntrospectedListGuesser = ({
-  children,
-  schema,
   fields,
+  readableFields,
+  writableFields,
+  schema,
   schemaAnalyzer,
+  children,
   ...props
 }) => {
   const [orderParameters, setOrderParameters] = useState([]);
@@ -56,7 +58,7 @@ export const IntrospectedListGuesser = ({
 
   let fieldChildren = children;
   if (!fieldChildren) {
-    fieldChildren = fields.map(field => (
+    fieldChildren = readableFields.map(field => (
       <FieldGuesser
         key={field.name}
         source={field.name}
@@ -64,7 +66,7 @@ export const IntrospectedListGuesser = ({
         resource={props.resource}
       />
     ));
-    displayOverrideCode(schema, fields);
+    displayOverrideCode(schema, readableFields);
   }
 
   return (

--- a/src/ShowGuesser.js
+++ b/src/ShowGuesser.js
@@ -26,16 +26,19 @@ const displayOverrideCode = (schema, fields) => {
 
 export const IntrospectedShowGuesser = ({
   fields,
-  children,
+  readableFields,
+  writableFields,
   schema,
+  schemaAnalyzer,
+  children,
   ...props
 }) => {
   let fieldChildren = children;
   if (!fieldChildren) {
-    fieldChildren = fields.map(field => (
+    fieldChildren = readableFields.map(field => (
       <FieldGuesser key={field.name} source={field.name} addLabel={true} />
     ));
-    displayOverrideCode(schema, fields);
+    displayOverrideCode(schema, readableFields);
   }
 
   return (

--- a/src/ShowGuesser.test.js
+++ b/src/ShowGuesser.test.js
@@ -3,7 +3,7 @@ import { TextField } from 'react-admin';
 import { shallow } from 'enzyme';
 import FieldGuesser from './FieldGuesser';
 
-import { API_INPUT_DATA, API_FIELDS_DATA } from './__fixtures__/parsedData';
+import { API_FIELDS_DATA } from './__fixtures__/parsedData';
 import { IntrospectedShowGuesser } from './ShowGuesser';
 
 describe('<ShowGuesser />', () => {
@@ -12,8 +12,7 @@ describe('<ShowGuesser />', () => {
       <IntrospectedShowGuesser
         resource="user"
         schema={{ name: 'users', title: 'User' }}
-        data={API_INPUT_DATA}
-        fields={API_FIELDS_DATA}
+        readableFields={API_FIELDS_DATA}
         id="ShowComponentId"
       />,
     );
@@ -33,8 +32,7 @@ describe('<ShowGuesser />', () => {
     const wrapper = shallow(
       <IntrospectedShowGuesser
         resource="user"
-        data={API_INPUT_DATA}
-        fields={API_FIELDS_DATA}
+        readableFields={API_FIELDS_DATA}
         id="ShowComponentId">
         <TextField source="id" label={'label of id'} />
         <TextField source="title" label={'label of title'} />

--- a/src/__fixtures__/parsedData.js
+++ b/src/__fixtures__/parsedData.js
@@ -1,40 +1,5 @@
 import { Field } from '@api-platform/api-doc-parser';
 
-export const ENTRYPOINT = 'http://entrypoint';
-
-export const RESOURCE_NAME = 'user';
-
-export const API_INPUT_DATA = {
-  resources: [
-    {
-      name: `${RESOURCE_NAME}`,
-      fields: [
-        new Field('fieldA', {
-          id: 'http://schema.org/fieldA',
-          range: 'http://www.w3.org/2001/XMLSchema#string',
-          reference: null,
-          required: true,
-        }),
-        new Field('fieldB', {
-          id: 'http://schema.org/fieldB',
-          range: 'http://www.w3.org/2001/XMLSchema#string',
-          reference: null,
-          required: true,
-        }),
-        new Field('deprecatedField', {
-          id: 'http://localhost/deprecatedField',
-          range: 'http://www.w3.org/2001/XMLSchema#string',
-          reference: null,
-          required: true,
-          deprecated: true,
-        }),
-      ],
-      parameters: [],
-      url: `${ENTRYPOINT}/users`,
-    },
-  ],
-};
-
 export const API_FIELDS_DATA = [
   new Field('fieldA', {
     id: 'http://schema.org/fieldA',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #256, #233
| License       | MIT
| Doc PR        | N/A

Writable fields should be used when creating or editing a resource, and readable fields should be used when listing or showing a resource.

Before this fix, all the fields were always displayed.