### PR TITLE
Better error handling and fix auth

### DIFF
--- a/src/AdminGuesser.test.js
+++ b/src/AdminGuesser.test.js
@@ -1,22 +1,11 @@
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import { AdminResourcesGuesser } from './AdminGuesser';
+import ResourceGuesser from './ResourceGuesser';
 import resources from './__fixtures__/resources';
 
 describe('<AdminGuesser />', () => {
   const renderer = new ShallowRenderer();
-
-  test('renders errors', () => {
-    const tree = renderer.render(
-      <AdminResourcesGuesser
-        error={new Error('Failed to fetch documentation')}
-        resources={resources}
-        loading={false}
-      />,
-    );
-
-    expect(tree).toMatchSnapshot();
-  });
 
   test('renders loading', () => {
     const tree = renderer.render(<AdminResourcesGuesser loading={true} />);
@@ -32,19 +21,18 @@ describe('<AdminGuesser />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  test('renders without data', () => {
-    const tree = renderer.render(<AdminResourcesGuesser loading={false} />);
+  test('renders with custom resources', () => {
+    const tree = renderer.render(
+      <AdminResourcesGuesser resources={resources} loading={false}>
+        <ResourceGuesser name="custom" />
+      </AdminResourcesGuesser>,
+    );
 
     expect(tree).toMatchSnapshot();
   });
 
-  test('renders errors without data', () => {
-    const tree = renderer.render(
-      <AdminResourcesGuesser
-        error={new Error('Failed to fetch documentation')}
-        loading={false}
-      />,
-    );
+  test('renders without data', () => {
+    const tree = renderer.render(<AdminResourcesGuesser loading={false} />);
 
     expect(tree).toMatchSnapshot();
   });

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,0 +1,33 @@
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
+import { ComponentPropType } from 'react-admin';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: null, errorInfo: null };
+  }
+
+  componentDidCatch(errorMessage, errorInfo) {
+    this.setState({ hasError: true, errorMessage, errorInfo });
+  }
+
+  render() {
+    const { error, children } = this.props;
+    const { hasError, errorMessage, errorInfo } = this.state;
+
+    return hasError
+      ? createElement(error, {
+          error: errorMessage,
+          errorInfo,
+        })
+      : children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  error: ComponentPropType,
+};
+
+export default ErrorBoundary;

--- a/src/__snapshots__/AdminGuesser.test.js.snap
+++ b/src/__snapshots__/AdminGuesser.test.js.snap
@@ -1,32 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<AdminGuesser /> renders errors 1`] = `
-<Error
-  error={[Error: API schema is not readable: Failed to fetch documentation]}
-  errorInfo={
-    Object {
-      "componentStack": null,
-    }
-  }
-/>
-`;
-
-exports[`<AdminGuesser /> renders errors without data 1`] = `
-<Error
-  error={[Error: API schema is not readable: Failed to fetch documentation]}
-  errorInfo={
-    Object {
-      "componentStack": null,
-    }
-  }
-/>
-`;
-
 exports[`<AdminGuesser /> renders loading 1`] = `
 <Loading
   loadingPrimary="ra.page.loading"
   loadingSecondary="ra.message.loading"
 />
+`;
+
+exports[`<AdminGuesser /> renders with custom resources 1`] = `
+<AdminUI
+  catchAll={[Function]}
+  layout={[Function]}
+  loading={[Function]}
+  loginPage={[Function]}
+  logout={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "propTypes": Object {
+        "className": [Function],
+        "redirectTo": [Function],
+      },
+      "render": [Function],
+    }
+  }
+>
+  <ResourceGuesser
+    name="custom"
+  />
+</AdminUI>
 `;
 
 exports[`<AdminGuesser /> renders without custom resources 1`] = `

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -414,9 +414,16 @@ export default (
     introspect: () =>
       apiSchema
         ? Promise.resolve({ data: apiSchema })
-        : apiDocumentationParser(entrypoint).then(({ api }) => {
-            apiSchema = api;
-            return { data: api };
-          }),
+        : apiDocumentationParser(entrypoint)
+            .then(({ api, customRoutes = [] }) => {
+              apiSchema = api;
+              return { data: api, customRoutes };
+            })
+            .catch(error => {
+              if (error.status) {
+                throw new Error(`Cannot fetch documentation: ${error.status}`);
+              }
+              throw error;
+            }),
   };
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #270
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/1024

Use error boundary (https://reactjs.org/docs/error-boundaries.html) for errors in `AdminGuesser` and add back `customRoutes` to handle authentication.

Better error handling when there is an error from the API when introspecting.