### PR TITLE
Passing json to HttpError body

### DIFF
--- a/src/hydra/fetchHydra.js
+++ b/src/hydra/fetchHydra.js
@@ -41,6 +41,7 @@ export default (url, options = {}) => {
                 '@value'
               ],
               status,
+              json,
             ),
           );
         })


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`HttpError` supports 3rd argument `body`, which could be used to "highlight"  errored field.