### PR TITLE
Use default per page parameter value

### DIFF
--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -216,7 +216,7 @@ export default (
 
         if (order) collectionUrl.searchParams.set(`order[${field}]`, order);
         if (page) collectionUrl.searchParams.set('page', page);
-        if (perPage) collectionUrl.searchParams.set('perPage', perPage);
+        if (perPage) collectionUrl.searchParams.set('itemsPerPage', perPage);
         if (params.filter) {
           const buildFilterParams = (key, nestedFilter, rootKey) => {
             const filterValue = nestedFilter[key];


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes and no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR allows to use the default api-platform `itemsPerPage` parameter instead of the current `perPage` (which is not the default framework parameter value)

Without this PR, the only easy way to use the `itemsPerPage` name for now is by doing:

```jsx
<ReferenceManyField label="Comments" reference="comments" target="post" perPage={3} filter={{ itemsPerPage: 3 }} pagination={<Pagination />} sort={{ field: 'createdAt', order: 'DESC' }}>
        ...
</ReferenceManyField>
```

It would be better to allow to customize this parameter on the admin side, or even better to extract it from the hydra doc. But using the official default value would be a good beginning.