### PR TITLE
Add partial pagination support

### DIFF
--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -4,6 +4,7 @@ import { Datagrid, List, EditButton, ShowButton } from 'react-admin';
 import FieldGuesser from './FieldGuesser';
 import FilterGuesser from './FilterGuesser';
 import Introspecter from './Introspecter';
+import Pagination from './list/Pagination';
 
 const displayOverrideCode = (schema, fields) => {
   if (process.env.NODE_ENV === 'production') return;
@@ -58,7 +59,7 @@ export const IntrospectedListGuesser = ({
   }
 
   return (
-    <List {...props}>
+    <List pagination={<Pagination />} {...props}>
       <Datagrid>
         {fieldChildren}
         {props.hasShow && <ShowButton />}

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -360,7 +360,16 @@ export default (
               ),
             ),
           )
-          .then((data) => ({ data, total: response.json['hydra:totalItems'] }));
+          .then((data) => ({
+            data,
+            total:
+              response.json?.['hydra:totalItems'] ||
+              (response.json?.['hydra:view']
+                ? response.json['hydra:view']?.['hydra:next']
+                  ? -2 // there is a next page
+                  : -1 // no next page
+                : -3), // no information
+          }));
 
       case DELETE:
         return Promise.resolve({ data: { id: null } });

--- a/src/list/Pagination.js
+++ b/src/list/Pagination.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Pagination, useTranslate } from 'react-admin';
+import { Button, Toolbar, makeStyles, useTheme } from '@material-ui/core';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+
+const useStyles = makeStyles({
+  spacer: {
+    flex: '1 1 100%',
+  },
+});
+
+export default (props) => {
+  const { page, total, setPage, ...rest } = props;
+
+  if (total >= 0) {
+    return <Pagination page={page} total={total} setPage={setPage} {...rest} />;
+  }
+
+  const classes = useStyles(props);
+  const theme = useTheme();
+  const translate = useTranslate();
+
+  return (
+    <Toolbar>
+      <div className={classes.spacer} />
+      {page > 1 && (
+        <Button color="primary" key="prev" onClick={() => setPage(page - 1)}>
+          {theme.direction === 'rtl' ? <ChevronRight /> : <ChevronLeft />}
+          {translate('ra.navigation.prev')}
+        </Button>
+      )}
+      {total < -1 && (
+        <Button color="primary" key="next" onClick={() => setPage(page + 1)}>
+          {translate('ra.navigation.next')}
+          {theme.direction === 'rtl' ? <ChevronLeft /> : <ChevronRight />}
+        </Button>
+      )}
+    </Toolbar>
+  );
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #276
| License       | MIT
| Doc PR        | N/A

Add a partial pagination support by adding a custom previous / next pagination component when needed.

It can be considered as a bug fix and as a new feature.

It uses some kind of hack for the hydra data provider to transmit pagination information to the pagination component, by using the `total` prop.

I don't think there is a better way to do so without modifying react-admin.

@fzaninotto / @djhi maybe it would be interesting if you could give your point of view?