### PR TITLE
Hydra: display empty page when `hydra:totalItems` is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.2.3
+
+* Hydra: display empty page when `hydra:totalItems` is 0
+
+## 2.2.2
+
+* Hydra: correctly display all errors
+
+## 2.2.1
+
+* Embedded support for array relation
+* Fix optimistic introspect calls
+* Hydra: better CORS error
+
 ## 2.2.0
 
 * Add embedded support (disabled by default, set `useEmbedded` to `true` in the Hydra data provider)

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -370,13 +370,13 @@ export default (
           )
           .then((data) => ({
             data,
-            total:
-              response.json?.['hydra:totalItems'] ||
-              (response.json?.['hydra:view']
-                ? response.json['hydra:view']?.['hydra:next']
-                  ? -2 // there is a next page
-                  : -1 // no next page
-                : -3), // no information
+            total: response.json.hasOwnProperty('hydra:totalItems')
+              ? response.json['hydra:totalItems']
+              : response.json?.['hydra:view']
+              ? response.json['hydra:view']?.['hydra:next']
+                ? -2 // there is a next page
+                : -1 // no next page
+              : -3, // no information
           }));
 
       case DELETE:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #320
| License       | MIT
| Doc PR        | N/A