### PR TITLE
Fix `loading` props usage in `AdminUI`

### DIFF
--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -40,6 +40,7 @@ export const AdminResourcesGuesser = ({
   includeDeprecated,
   resources,
   loading,
+  loadingPage,
   ...rest
 }) => {
   if (loading) {
@@ -57,7 +58,7 @@ export const AdminResourcesGuesser = ({
     displayOverrideCode(guessResources);
   }
 
-  return <AdminUI {...rest}>{resourceChildren}</AdminUI>;
+  return <AdminUI loading={loadingPage} {...rest}>{resourceChildren}</AdminUI>;
 };
 
 const defaultTheme = createMuiTheme({
@@ -90,6 +91,7 @@ const AdminGuesser = ({
   appLayout,
   layout = Layout,
   loginPage,
+  loading: loadingPage,
   locale,
   theme = defaultTheme,
   // Other props
@@ -160,6 +162,7 @@ const AdminGuesser = ({
           loading={loading}
           layout={appLayout || layout}
           loginPage={loginPage}
+          loadingPage={loadingPage}
           theme={theme}
           {...rest}>
           {children}

--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -40,11 +40,11 @@ export const AdminResourcesGuesser = ({
   includeDeprecated,
   resources,
   loading,
-  loadingPage,
+  loadingPage: LoadingPage = Loading,
   ...rest
 }) => {
   if (loading) {
-    return <Loading />;
+    return <LoadingPage />;
   }
 
   let resourceChildren = children;
@@ -59,7 +59,7 @@ export const AdminResourcesGuesser = ({
   }
 
   return (
-    <AdminUI loading={loadingPage} {...rest}>
+    <AdminUI loading={LoadingPage} {...rest}>
       {resourceChildren}
     </AdminUI>
   );

--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -58,7 +58,11 @@ export const AdminResourcesGuesser = ({
     displayOverrideCode(guessResources);
   }
 
-  return <AdminUI loading={loadingPage} {...rest}>{resourceChildren}</AdminUI>;
+  return (
+    <AdminUI loading={loadingPage} {...rest}>
+      {resourceChildren}
+    </AdminUI>
+  );
 };
 
 const defaultTheme = createMuiTheme({


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Fix loading props usage in `<HydraAdmin />` to allow `loadingPage` usage as `loading` in `react-admin` `<AdminUI />` component and be able to override `<Loading />` component without define the admin to be in a loading state.
