### PR TITLE
feat: add custom searchParams for the Hydra data provider methods

### DIFF
--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -181,7 +181,15 @@ export default (
   /**
    * @param {string} type
    * @param {string} resource
-   * @param {Object} params
+   * @param {{
+   *   id: ?string,
+   *   data: ?Object,
+   *   target: ?string,
+   *   filter: ?Object,
+   *   pagination: ?Object,
+   *   sort: ?Object,
+   *   searchParams: ?Object
+   * }} params
    *
    * @returns {Object}
    */
@@ -189,6 +197,17 @@ export default (
     const entrypointUrl = new URL(entrypoint, window.location.href);
     const collectionUrl = new URL(`${entrypoint}/${resource}`, entrypointUrl);
     const itemUrl = new URL(params.id, entrypointUrl);
+    const searchParams = params.searchParams || {};
+    for (const searchParamKey in searchParams) {
+      if (!searchParams.hasOwnProperty(searchParamKey)) {
+        continue;
+      }
+      collectionUrl.searchParams.set(
+        searchParamKey,
+        searchParams[searchParamKey],
+      );
+      itemUrl.searchParams.set(searchParamKey, searchParams[searchParamKey]);
+    }
 
     switch (type) {
       case CREATE:
@@ -399,7 +418,15 @@ export default (
   /**
    * @param {string} type
    * @param {string} resource
-   * @param {Object} params
+   * @param {{
+   *   id: ?string,
+   *   data: ?Object,
+   *   target: ?string,
+   *   filter: ?Object,
+   *   pagination: ?Object,
+   *   sort: ?Object,
+   *   searchParams: ?Object
+   * }} params
    *
    * @returns {Promise}
    */

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -104,7 +104,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
   });
   const dataProvider = dataProviderFactory('entrypoint', mockFetchHydra);
 
-  test('React Admin get list with filter parameters', () => {
+  test('React Admin get list with filter parameters and custom search params', () => {
     return dataProvider
       .getList('resource', {
         pagination: {},
@@ -119,27 +119,29 @@ describe('Transform a React Admin request to an Hydra request', () => {
           nested_date: { date: { before: '2000' } },
           nested_range: { range: { between: '12.99..15.99' } },
         },
+        searchParams: { pagination: true },
       })
       .then(() => {
         const searchParams = Array.from(
           mockFetchHydra.mock.calls[0][0].searchParams.entries(),
         );
-        expect(searchParams[0]).toEqual(['simple', 'foo']);
-        expect(searchParams[1]).toEqual(['nested.param', 'bar']);
-        expect(searchParams[2]).toEqual(['sub_nested.sub.param', 'true']);
-        expect(searchParams[3]).toEqual(['array[0]', '/iri/1']);
-        expect(searchParams[4]).toEqual(['array[1]', '/iri/2']);
-        expect(searchParams[5]).toEqual([
+        expect(searchParams[0]).toEqual(['pagination', 'true']);
+        expect(searchParams[1]).toEqual(['simple', 'foo']);
+        expect(searchParams[2]).toEqual(['nested.param', 'bar']);
+        expect(searchParams[3]).toEqual(['sub_nested.sub.param', 'true']);
+        expect(searchParams[4]).toEqual(['array[0]', '/iri/1']);
+        expect(searchParams[5]).toEqual(['array[1]', '/iri/2']);
+        expect(searchParams[6]).toEqual([
           'nested_array.nested[0]',
           '/nested_iri/1',
         ]);
-        expect(searchParams[6]).toEqual([
+        expect(searchParams[7]).toEqual([
           'nested_array.nested[1]',
           '/nested_iri/2',
         ]);
-        expect(searchParams[7]).toEqual(['exists[foo]', 'true']);
-        expect(searchParams[8]).toEqual(['nested_date.date[before]', '2000']);
-        expect(searchParams[9]).toEqual([
+        expect(searchParams[8]).toEqual(['exists[foo]', 'true']);
+        expect(searchParams[9]).toEqual(['nested_date.date[before]', '2000']);
+        expect(searchParams[10]).toEqual([
           'nested_range.range[between]',
           '12.99..15.99',
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Supersedes https://github.com/api-platform/admin/pull/323.

Adds the possibility to add custom search params when calling a Hydra data provider method.

For instance:
```js
const useHardDelete = (resource, id, previousData, options) =>
  useMutation(
    { type: 'delete', resource, payload: { id, previousData, searchParams: { withDeleted: true } } },
    options,
  );
```