### PR TITLE
Fix customRoutes default value on AdminGuesser

### DIFF
--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -136,7 +136,7 @@ const AdminGuesser = ({
 
     dataProvider
       .introspect()
-      .then(({ data, customRoutes }) => {
+      .then(({ data, customRoutes = [] }) => {
         setResources(data.resources);
         setAddedCustomRoutes(customRoutes);
         setLoading(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Fix possible issues with `@testing-library/react`: `TypeError: addedCustomRoutes is not iterable`