### PR TITLE
fix: apiSchema should not be cached if there are no resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.0
 
 * Add `useIntrospection` hook in order to ask for a new introspection if needed
+* Hydra: `apiSchema` should not be cached if there are no resources
 
 ## 2.3.0
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -491,7 +491,9 @@ export default (
         ? Promise.resolve({ data: apiSchema })
         : apiDocumentationParser(entrypoint)
             .then(({ api, customRoutes = [] }) => {
-              apiSchema = api;
+              if (api.resources.length > 0) {
+                apiSchema = api;
+              }
               return { data: api, customRoutes };
             })
             .catch((err) => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`apiSchema` was wrongly cached when there were no resources.

It didn't cause an issue, because this cache was never used, but it can now that an introspection can be asked again.