### PR TITLE
fix: introspection should be done before loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.2
+
+* Introspection should be done before loading
+
 ## 2.4.1
 
 * Set loading when introspecting with `useIntrospection`

--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -145,8 +145,8 @@ const AdminGuesser = ({
       .then(({ data, customRoutes = [] }) => {
         setResources(data.resources);
         setAddedCustomRoutes(customRoutes);
-        setLoading(false);
         setIntrospect(false);
+        setLoading(false);
       })
       .catch((error) => {
         // Allow error to be caught by the error boundary


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Introspection should be set to `false` before loading.

This prevents an issue when loading a resource URL directly (the `AdminUI` was mounted twice).