### PR TITLE
[Hydra] Manage file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0
+
+* Hydra: manage file upload (use `FormData` instead of JSON)
+
 ## 2.4.3
 
 * Humanize `ReferenceInput` and `ReferenceArrayInput` label in `InputGuesser`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

When a [FileInput](https://marmelab.com/react-admin/Inputs.html#fileinput) is used, the Hydra data provider now uses `FormData` instead of JSON.
This will allow to manage file upload without relying on a tedious decoration of the data provider.

Supersedes https://github.com/api-platform/admin/pull/246.