### PR TITLE
Fix schemaAnalyzer errors with logoutIfAccessDenied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.1
+
+* Call `logoutIfAccessDenied` if the `schemaAnalyzer` throws an error (to logout in case of an unauthorized access)
+
 ## 2.5.0
 
 * Hydra: manage file upload (use `FormData` instead of JSON)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Catch `schemaAnalyzer` erros and pipe them to `logoutIfAccessDenied` to handle `401: Unauthorized`
