### PR TITLE
Fix ResourceGuesser Proptypes

### DIFF
--- a/src/ResourceGuesser.js
+++ b/src/ResourceGuesser.js
@@ -17,7 +17,7 @@ const ResourceGuesser = ({ list, edit, create, show, ...props }) => (
 );
 
 ResourceGuesser.propTypes = {
-  resource: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
 };
 
 export default ResourceGuesser;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Fix `ResourceGuesser` Proptypes, rename `resource` to `name` to be consistent with `react-admin`