### PR TITLE
Sort for nested properties in ListGuesser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.6
+
+* Add sort for nested properties in ListGuesser
+
 ## 2.5.5
 
 * Hydra: use `fetchJsonLd` when expanding an error (to use authorization header)

--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -47,14 +47,21 @@ export const IntrospectedListGuesser = ({
 
   let fieldChildren = children;
   if (!fieldChildren) {
-    fieldChildren = readableFields.map((field) => (
-      <FieldGuesser
-        key={field.name}
-        source={field.name}
-        sortable={orderParameters.includes(field.name)}
-        resource={props.resource}
-      />
-    ));
+    fieldChildren = readableFields.map((field) => {
+      const orderField = orderParameters.find(
+        (orderParameter) => orderParameter.split('.')[0] === field.name,
+      );
+
+      return (
+        <FieldGuesser
+          key={field.name}
+          source={field.name}
+          sortable={!!orderField}
+          sortBy={orderField}
+          resource={props.resource}
+        />
+      );
+    });
     displayOverrideCode(schema, readableFields);
   }
 

--- a/src/hydra/schemaAnalyzer.js
+++ b/src/hydra/schemaAnalyzer.js
@@ -37,7 +37,11 @@ const getOrderParametersFromSchema = (schema) => {
       .map((orderFilter) =>
         orderFilter.replace(ORDER_MARKER, '').replace(']', ''),
       )
-      .filter((filter) => authorizedFields.includes(filter)),
+      .filter((filter) =>
+        authorizedFields.includes(
+          filter.split('.')[0], // split to manage nested properties
+        ),
+      ),
   );
 };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When an order filter was added for a nested property (https://api-platform.com/docs/core/filters/#filtering-on-nested-properties), the field in `ListGuesser` was not sortable.
Now the first order filter will be used by default to sort it.