### PR TITLE
Do not display user menu if there is no auth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.5.7
 
-* Add `rowClick` prop in `ListGuesser`	* Add `rowClick` prop in `ListGuesser`
+* Add `rowClick` prop in `ListGuesser`
 * Add eslint hook rules
+* Do not display user menu if there is no auth provider
 
 ## 2.5.6
 

--- a/src/layout/AppBar.js
+++ b/src/layout/AppBar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AppBar } from 'react-admin';
+import { AppBar, useAuthProvider } from 'react-admin';
 import { Typography, withStyles } from '@material-ui/core';
 
 import Logo from './Logo';
@@ -16,17 +16,21 @@ const styles = {
   },
 };
 
-const CustomAppBar = withStyles(styles)(({ classes, ...props }) => (
-  <AppBar {...props}>
-    <Typography
-      variant="h6"
-      color="inherit"
-      className={classes.title}
-      id="react-admin-title"
-    />
-    <Logo />
-    <span className={classes.spacer} />
-  </AppBar>
-));
+const CustomAppBar = withStyles(styles)(({ classes, userMenu, ...props }) => {
+  const authProvider = useAuthProvider();
+
+  return (
+    <AppBar userMenu={userMenu || !!authProvider} {...props}>
+      <Typography
+        variant="h6"
+        color="inherit"
+        className={classes.title}
+        id="react-admin-title"
+      />
+      <Logo />
+      <span className={classes.spacer} />
+    </AppBar>
+  );
+});
 
 export default CustomAppBar;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | https://github.com/api-platform/admin/issues/314
| License       | MIT
| Doc PR        | 

Even when no `authProvider` is configured, the user menu was displayed.