### PR TITLE
Do not use guessers in ResourceGuesser if falsy props are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 2.5.7
 
 * Add `rowClick` prop in `ListGuesser`
-* Add eslint hook rules
 * Do not display user menu if there is no auth provider
+* Do not use guessers in `ResourceGuesser` if `create`, `edit`, `show`, `list` props have a falsy value
+* Add ESLint hook rules
 
 ## 2.5.6
 

--- a/src/ResourceGuesser.js
+++ b/src/ResourceGuesser.js
@@ -9,10 +9,10 @@ import ShowGuesser from './ShowGuesser';
 const ResourceGuesser = ({ list, edit, create, show, ...props }) => (
   <Resource
     {...props}
-    create={create || CreateGuesser}
-    edit={edit || EditGuesser}
-    list={list || ListGuesser}
-    show={show || ShowGuesser}
+    create={undefined === create ? CreateGuesser : create}
+    edit={undefined === edit ? EditGuesser : edit}
+    list={undefined === list ? ListGuesser : list}
+    show={undefined === show ? ShowGuesser : show}
   />
 );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A