### PR TITLE
Fix customSagas prop type

### DIFF
--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -198,7 +198,7 @@ AdminGuesser.propTypes = {
   i18nProvider: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   history: PropTypes.object,
   customReducers: PropTypes.object,
-  customSagas: PropTypes.object,
+  customSagas: PropTypes.array,
   initialState: PropTypes.object,
   schemaAnalyzer: PropTypes.object.isRequired,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #337
| License       | MIT
| Doc PR        | - 

`customSagas` passed "as is" from `AdminGuesser` to react-admin's `AdminContext` and [it defined as array there](https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/core/CoreAdminContext.tsx#L32), not object. 
So this PR is a fix