### PR TITLE
fix: downgrade history and remove final-form-submit-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.6.2
+
+* Downgrade history
+* Remove final-form-submit-errors
+
+## 2.6.1
+
+* Bump dependencies (history, jsonld)
+
 ## 2.6.0
 
 * Submission errors per field

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@api-platform/api-doc-parser": "^0.12.0",
-    "final-form-submit-errors": "^0.1.0",
-    "history": "^5.0.0",
+    "history": "^4.7.0",
     "jsonld": "^5.2.0",
     "lodash.isplainobject": "^4.0.6",
     "prop-types": "^15.6.2",

--- a/src/CreateGuesser.js
+++ b/src/CreateGuesser.js
@@ -7,11 +7,6 @@ import {
   useNotify,
   useRedirect,
 } from 'react-admin';
-import arrayMutators from 'final-form-arrays';
-import {
-  submitErrorsMutators,
-  SubmitErrorsSpy,
-} from 'final-form-submit-errors';
 import InputGuesser from './InputGuesser';
 import Introspecter from './Introspecter';
 
@@ -134,10 +129,6 @@ export const IntrospectedCreateGuesser = ({
     <Create resource={resource} basePath={basePath} {...props}>
       <SimpleForm
         save={save}
-        mutators={{
-          ...arrayMutators,
-          ...submitErrorsMutators,
-        }}
         initialValues={initialValues}
         validate={validate}
         toolbar={toolbar}
@@ -147,7 +138,6 @@ export const IntrospectedCreateGuesser = ({
         warnWhenUnsavedChanges={warnWhenUnsavedChanges}
         sanitizeEmptyValues={sanitizeEmptyValues}
         component={simpleFormComponent}>
-        <SubmitErrorsSpy />
         {inputChildren}
       </SimpleForm>
     </Create>

--- a/src/EditGuesser.js
+++ b/src/EditGuesser.js
@@ -7,11 +7,6 @@ import {
   useNotify,
   useRedirect,
 } from 'react-admin';
-import arrayMutators from 'final-form-arrays';
-import {
-  submitErrorsMutators,
-  SubmitErrorsSpy,
-} from 'final-form-submit-errors';
 import InputGuesser from './InputGuesser';
 import Introspecter from './Introspecter';
 
@@ -144,10 +139,6 @@ export const IntrospectedEditGuesser = ({
       {...props}>
       <SimpleForm
         save={mutationMode !== 'pessimistic' ? undefined : save}
-        mutators={{
-          ...arrayMutators,
-          ...submitErrorsMutators,
-        }}
         initialValues={initialValues}
         validate={validate}
         redirect={redirectTo}
@@ -158,7 +149,6 @@ export const IntrospectedEditGuesser = ({
         warnWhenUnsavedChanges={warnWhenUnsavedChanges}
         sanitizeEmptyValues={sanitizeEmptyValues}
         component={simpleFormComponent}>
-        <SubmitErrorsSpy />
         {inputChildren}
       </SimpleForm>
     </Edit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #382
| License       | MIT
| Doc PR        | N/A

Downgrade history (version 5 is not compatible with react-admin / connected-react-router).
Remove final-form-submit-errors since it has been integrated into react-admin.