### PR TITLE
feat: Add formEnctype support in data provider to force multipart encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.6.5
 
-* Accept 'formEnctype: multipart' in data passed to data provider to force multipart encoding.
+* Accept 'formEnctype: multipart/form-data' in data passed to data provider to force multipart encoding.
 
 ## 2.6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.5
+
+* Accept 'formEnctype: multipart' in data passed to data provider to force multipart encoding.
+
 ## 2.6.4
 
 * Call `toJSON` instead of `JSON.stringify` when there is a `toJSON` property in a form data value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.6.5
 
-* Accept 'formEnctype: multipart/form-data' in data passed to data provider to force multipart encoding.
+* Accept `extraInformation` in data passed to data provider. Use a `hasFileField` field to force multipart encoding.
 
 ## 2.6.4
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -345,11 +345,19 @@ export default (
         });
 
       case UPDATE:
+        const getUpdateHttpVerb = (params) => {
+          if (params.data && params.data.formMethod && params.data.formMethod === 'POST') {
+            delete params.data.formMethod;
+            return 'POST';
+          }
+          return 'PUT';
+        }
+        const updateHttpVerb = getUpdateHttpVerb(params);
         return transformReactAdminDataToRequestBody(resource, params.data).then(
           (body) => ({
             options: {
               body,
-              method: 'PUT',
+              method: updateHttpVerb,
             },
             url: itemUrl,
           }),

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -179,9 +179,7 @@ export default (
       const containFile = (element) =>
         isPlainObject(element) &&
         Object.values(element).some((value) => value instanceof File);
-      const containsMultipartOverride = (data) => {
-        return data.formEnctype === 'multipart/form-data' ? true : false;
-      };
+      const containsMultipartOverride = (data) => data.formEnctype === 'multipart/form-data';
 
       if (
         !values.some((value) => containFile(value)) &&

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -179,8 +179,19 @@ export default (
       const containFile = (element) =>
         isPlainObject(element) &&
         Object.values(element).some((value) => value instanceof File);
+      const containsMultipartOverride = (data) => {
+        if (data.formEnctype && data.formEnctype === 'multipart') {
+          delete data.formEnctype;
+          return true;
+        } else {
+          return false;
+        }
+      };
 
-      if (!values.some((value) => containFile(value))) {
+      if (
+        !values.some((value) => containFile(value)) &&
+        !containsMultipartOverride(data)
+      ) {
         return JSON.stringify(data);
       }
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -180,12 +180,7 @@ export default (
         isPlainObject(element) &&
         Object.values(element).some((value) => value instanceof File);
       const containsMultipartOverride = (data) => {
-        if (data.formEnctype && data.formEnctype === 'multipart/form-data') {
-          delete data.formEnctype;
-          return true;
-        } else {
-          return false;
-        }
+        return data.formEnctype === 'multipart/form-data' ? true : false;
       };
 
       if (
@@ -193,6 +188,10 @@ export default (
         !containsMultipartOverride(data)
       ) {
         return JSON.stringify(data);
+      }
+
+      if(containsMultipartOverride(data)){
+        delete data.formEnctype;
       }
 
       // If data contains a file, use FormData instead of JSON.
@@ -345,7 +344,8 @@ export default (
         });
 
       case UPDATE:
-        const updateHttpVerb = (params.data?.formMethod === 'POST') ? 'POST' : 'PUT';
+        const updateHttpVerb =
+          params.data?.formMethod === 'POST' ? 'POST' : 'PUT';
         delete params?.data?.formMethod;
         return transformReactAdminDataToRequestBody(resource, params.data).then(
           (body) => ({

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -346,12 +346,16 @@ export default (
 
       case UPDATE:
         const getUpdateHttpVerb = (params) => {
-          if (params.data && params.data.formMethod && params.data.formMethod === 'POST') {
+          if (
+            params.data &&
+            params.data.formMethod &&
+            params.data.formMethod === 'POST'
+          ) {
             delete params.data.formMethod;
             return 'POST';
           }
           return 'PUT';
-        }
+        };
         const updateHttpVerb = getUpdateHttpVerb(params);
         return transformReactAdminDataToRequestBody(resource, params.data).then(
           (body) => ({

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -345,18 +345,8 @@ export default (
         });
 
       case UPDATE:
-        const getUpdateHttpVerb = (params) => {
-          if (
-            params.data &&
-            params.data.formMethod &&
-            params.data.formMethod === 'POST'
-          ) {
-            delete params.data.formMethod;
-            return 'POST';
-          }
-          return 'PUT';
-        };
-        const updateHttpVerb = getUpdateHttpVerb(params);
+        const updateHttpVerb = (params.data?.formMethod === 'POST') ? 'POST' : 'PUT';
+        delete params?.data?.formMethod;
         return transformReactAdminDataToRequestBody(resource, params.data).then(
           (body) => ({
             options: {

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -342,8 +342,8 @@ export default (
         });
 
       case UPDATE:
-        const updateHttpVerb =
-          params.data?.formMethod === 'POST' ? 'POST' : 'PUT';
+        const updateHttpMethod =
+          params.data?.formMethod ?? 'PUT';
         delete params?.data?.formMethod;
         return transformReactAdminDataToRequestBody(resource, params.data).then(
           (body) => ({

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -190,7 +190,7 @@ export default (
         return JSON.stringify(data);
       }
 
-      if(containsMultipartOverride(data)){
+      if (containsMultipartOverride(data)) {
         delete data.formEnctype;
       }
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -180,7 +180,7 @@ export default (
         isPlainObject(element) &&
         Object.values(element).some((value) => value instanceof File);
       const containsMultipartOverride = (data) => {
-        if (data.formEnctype && data.formEnctype === 'multipart') {
+        if (data.formEnctype && data.formEnctype === 'multipart/form-data') {
           delete data.formEnctype;
           return true;
         } else {

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -177,13 +177,12 @@ export default (
     return convertReactAdminDataToHydraData(apiResource, data).then((data) => {
       const values = Object.values(data);
       const containFile = (element) =>
-        isPlainObject(element) &&
-        Object.values(element).some((value) => value instanceof File);
-      const containFileField = (data) => data.extraInformation?.hasFileField;
+        (isPlainObject(element) &&
+        Object.values(element).some((value) => value instanceof File)) || 
+        element.hasFileField;
       
       if (
-        !values.some((value) => containFile(value)) &&
-        !containFileField(data)
+        !values.some((value) => containFile(value))
       ) {
         delete data.extraInformation;
         return JSON.stringify(data);

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -217,7 +217,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         foo: 'foo',
         extraInformation: {
           hasFileField: true,
-        }
+        },
       },
     });
     const url = mockFetchHydra.mock.calls[3][0];
@@ -241,9 +241,6 @@ describe('Transform a React Admin request to an Hydra request', () => {
       data: {
         foo: 'foo',
         bar: 'baz',
-        extraInformation: {
-          hasFileField: false
-        },
       },
     });
     const url = mockFetchHydra.mock.calls[4][0];
@@ -264,7 +261,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         foo: 'foo',
         bar: 'baz',
         extraInformation: {
-          hasFileField: true
+          hasFileField: true,
         },
       },
     });
@@ -281,49 +278,4 @@ describe('Transform a React Admin request to an Hydra request', () => {
       ['bar', 'baz'],
     ]);
   });
-
-  test('React Admin update - ignore extraInformation even when not using file field', async () => {
-    await dataProvider.introspect();
-    await dataProvider.update('resource', {
-      id: '/entrypoint/resource/1',
-      data: {
-        foo: 'foo',
-        bar: 'baz',
-        extraInformation: {
-          hasFileField: false
-        },
-      },
-    });
-    const url = mockFetchHydra.mock.calls[6][0];
-    expect(url).toBeInstanceOf(URL);
-    expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
-    const options = mockFetchHydra.mock.calls[6][1];
-    expect(options).toHaveProperty('method');
-    expect(options.method).toEqual('PUT');
-    expect(options).toHaveProperty('body');
-    expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
-  });
-
-  test('React Admin create - ignore extraInformation even when not using file field', async () => {
-    await dataProvider.introspect();
-    await dataProvider.create('resource', {
-      data: {
-        foo: 'foo',
-        bar: 'baz',
-        extraInformation: {
-          hasFileField: false,
-          anything: true,
-        },
-      },
-    });
-    const url = mockFetchHydra.mock.calls[7][0];
-    expect(url).toBeInstanceOf(URL);
-    expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
-    const options = mockFetchHydra.mock.calls[7][1];
-    expect(options).toHaveProperty('method');
-    expect(options.method).toEqual('POST');
-    expect(options).toHaveProperty('body');
-    expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
-  });
-  
 });

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -218,4 +218,31 @@ describe('Transform a React Admin request to an Hydra request', () => {
         ]);
       });
   });
+
+  test('React Admin create multipart override', async () => {
+    await dataProvider.introspect();
+
+    return dataProvider
+      .create('resource', {
+        data: {
+          bar: 'baz',
+          foo: 'foo',
+          formEnctype: 'multipart',
+        },
+      })
+      .then(() => {
+        const url = mockFetchHydra.mock.calls[3][0];
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
+        const options = mockFetchHydra.mock.calls[3][1];
+        expect(options).toHaveProperty('method');
+        expect(options.method).toEqual('POST');
+        expect(options).toHaveProperty('body');
+        expect(options.body).toBeInstanceOf(FormData);
+        expect(Array.from(options.body.entries())).toEqual([
+          ['bar', 'baz'],
+          ['foo', 'foo'],
+        ]);
+      });
+  });
 });

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -1,4 +1,6 @@
 import { Api, Field, Resource } from '@api-platform/api-doc-parser';
+import { string } from 'prop-types';
+import { number } from 'prop-types';
 import dataProviderFactory, {
   transformJsonLdDocumentToReactAdminDocument,
 } from './dataProvider';
@@ -242,6 +244,86 @@ describe('Transform a React Admin request to an Hydra request', () => {
         expect(Array.from(options.body.entries())).toEqual([
           ['bar', 'baz'],
           ['foo', 'foo'],
+        ]);
+      });
+  });
+
+  test('React Admin update', async () => {
+    await dataProvider.introspect();
+
+    return dataProvider
+      .update('resource', {
+        id: '/entrypoint/resource/1',
+        data: {
+          foo: 'foo',
+          bar: 'baz',
+        },
+      })
+      .then(() => {
+        const url = mockFetchHydra.mock.calls[4][0];
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+        const options = mockFetchHydra.mock.calls[4][1];
+        expect(options).toHaveProperty('method');
+        expect(options.method).toEqual('PUT');
+        expect(options).toHaveProperty('body');
+        expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
+      });
+  });
+
+  test('React Admin update enctype override', async () => {
+    await dataProvider.introspect();
+
+    return dataProvider
+      .update('resource', {
+        id: '/entrypoint/resource/1',
+        data: {
+          foo: 'foo',
+          bar: 'baz',
+          formEnctype: 'multipart',
+        },
+      })
+      .then(() => {
+        const url = mockFetchHydra.mock.calls[5][0];
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+        const options = mockFetchHydra.mock.calls[5][1];
+        expect(options).toHaveProperty('method');
+        expect(options.method).toEqual('PUT');
+        expect(options).toHaveProperty('body');
+        expect(options.body).toBeInstanceOf(FormData);
+        expect(Array.from(options.body.entries())).toEqual([
+          ['foo', 'foo'],
+          ['bar', 'baz'],
+        ]);
+      });
+  });
+
+  test('React Admin update enctype and method override', async () => {
+    await dataProvider.introspect();
+
+    return dataProvider
+      .update('resource', {
+        id: '/entrypoint/resource/1',
+        data: {
+          foo: 'foo',
+          bar: 'baz',
+          formEnctype: 'multipart',
+          formMethod: 'POST',
+        },
+      })
+      .then(() => {
+        const url = mockFetchHydra.mock.calls[6][0];
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+        const options = mockFetchHydra.mock.calls[6][1];
+        expect(options).toHaveProperty('method');
+        expect(options.method).toEqual('POST');
+        expect(options).toHaveProperty('body');
+        expect(options.body).toBeInstanceOf(FormData);
+        expect(Array.from(options.body.entries())).toEqual([
+          ['foo', 'foo'],
+          ['bar', 'baz'],
         ]);
       });
   });

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -260,7 +260,9 @@ describe('Transform a React Admin request to an Hydra request', () => {
       .then(() => {
         const url = mockFetchHydra.mock.calls[4][0];
         expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+        expect(url.toString()).toEqual(
+          'http://localhost/entrypoint/resource/1',
+        );
         const options = mockFetchHydra.mock.calls[4][1];
         expect(options).toHaveProperty('method');
         expect(options.method).toEqual('PUT');
@@ -284,7 +286,9 @@ describe('Transform a React Admin request to an Hydra request', () => {
       .then(() => {
         const url = mockFetchHydra.mock.calls[5][0];
         expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+        expect(url.toString()).toEqual(
+          'http://localhost/entrypoint/resource/1',
+        );
         const options = mockFetchHydra.mock.calls[5][1];
         expect(options).toHaveProperty('method');
         expect(options.method).toEqual('PUT');
@@ -313,7 +317,9 @@ describe('Transform a React Admin request to an Hydra request', () => {
       .then(() => {
         const url = mockFetchHydra.mock.calls[6][0];
         expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+        expect(url.toString()).toEqual(
+          'http://localhost/entrypoint/resource/1',
+        );
         const options = mockFetchHydra.mock.calls[6][1];
         expect(options).toHaveProperty('method');
         expect(options.method).toEqual('POST');

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -227,7 +227,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         data: {
           bar: 'baz',
           foo: 'foo',
-          formEnctype: 'multipart',
+          formEnctype: 'multipart/form-data',
         },
       })
       .then(() => {
@@ -280,7 +280,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         data: {
           foo: 'foo',
           bar: 'baz',
-          formEnctype: 'multipart',
+          formEnctype: 'multipart/form-data',
         },
       })
       .then(() => {
@@ -310,7 +310,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         data: {
           foo: 'foo',
           bar: 'baz',
-          formEnctype: 'multipart',
+          formEnctype: 'multipart/form-data',
           formMethod: 'POST',
         },
       })

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -1,6 +1,4 @@
 import { Api, Field, Resource } from '@api-platform/api-doc-parser';
-import { string } from 'prop-types';
-import { number } from 'prop-types';
 import dataProviderFactory, {
   transformJsonLdDocumentToReactAdminDocument,
 } from './dataProvider';

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -209,13 +209,15 @@ describe('Transform a React Admin request to an Hydra request', () => {
     ]);
   });
 
-  test('React Admin create multipart override', async () => {
+  test('React Admin create with file field', async () => {
     await dataProvider.introspect();
     await dataProvider.create('resource', {
       data: {
         bar: 'baz',
         foo: 'foo',
-        formEnctype: 'multipart/form-data',
+        extraInformation: {
+          hasFileField: true,
+        }
       },
     });
     const url = mockFetchHydra.mock.calls[3][0];
@@ -239,6 +241,9 @@ describe('Transform a React Admin request to an Hydra request', () => {
       data: {
         foo: 'foo',
         bar: 'baz',
+        extraInformation: {
+          hasFileField: false
+        },
       },
     });
     const url = mockFetchHydra.mock.calls[4][0];
@@ -251,45 +256,22 @@ describe('Transform a React Admin request to an Hydra request', () => {
     expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
   });
 
-  test('React Admin update enctype override', async () => {
+  test('React Admin update with file field', async () => {
     await dataProvider.introspect();
     await dataProvider.update('resource', {
       id: '/entrypoint/resource/1',
       data: {
         foo: 'foo',
         bar: 'baz',
-        formEnctype: 'multipart/form-data',
+        extraInformation: {
+          hasFileField: true
+        },
       },
     });
     const url = mockFetchHydra.mock.calls[5][0];
     expect(url).toBeInstanceOf(URL);
     expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
     const options = mockFetchHydra.mock.calls[5][1];
-    expect(options).toHaveProperty('method');
-    expect(options.method).toEqual('PUT');
-    expect(options).toHaveProperty('body');
-    expect(options.body).toBeInstanceOf(FormData);
-    expect(Array.from(options.body.entries())).toEqual([
-      ['foo', 'foo'],
-      ['bar', 'baz'],
-    ]);
-  });
-
-  test('React Admin update enctype and method override', async () => {
-    await dataProvider.introspect();
-    await dataProvider.update('resource', {
-      id: '/entrypoint/resource/1',
-      data: {
-        foo: 'foo',
-        bar: 'baz',
-        formEnctype: 'multipart/form-data',
-        formMethod: 'POST',
-      },
-    });
-    const url = mockFetchHydra.mock.calls[6][0];
-    expect(url).toBeInstanceOf(URL);
-    expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
-    const options = mockFetchHydra.mock.calls[6][1];
     expect(options).toHaveProperty('method');
     expect(options.method).toEqual('POST');
     expect(options).toHaveProperty('body');
@@ -299,4 +281,49 @@ describe('Transform a React Admin request to an Hydra request', () => {
       ['bar', 'baz'],
     ]);
   });
+
+  test('React Admin update - ignore extraInformation even when not using file field', async () => {
+    await dataProvider.introspect();
+    await dataProvider.update('resource', {
+      id: '/entrypoint/resource/1',
+      data: {
+        foo: 'foo',
+        bar: 'baz',
+        extraInformation: {
+          hasFileField: false
+        },
+      },
+    });
+    const url = mockFetchHydra.mock.calls[6][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+    const options = mockFetchHydra.mock.calls[6][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('PUT');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
+  });
+
+  test('React Admin create - ignore extraInformation even when not using file field', async () => {
+    await dataProvider.introspect();
+    await dataProvider.create('resource', {
+      data: {
+        foo: 'foo',
+        bar: 'baz',
+        extraInformation: {
+          hasFileField: false,
+          anything: true,
+        },
+      },
+    });
+    const url = mockFetchHydra.mock.calls[7][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
+    const options = mockFetchHydra.mock.calls[7][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('POST');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
+  });
+  
 });

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -118,217 +118,185 @@ describe('Transform a React Admin request to an Hydra request', () => {
     mockApiDocumentationParser,
   );
 
-  test('React Admin get list with filter parameters and custom search params', () => {
-    return dataProvider
-      .getList('resource', {
-        pagination: {},
-        sort: {},
-        filter: {
-          simple: 'foo',
-          nested: { param: 'bar' },
-          sub_nested: { sub: { param: true } },
-          array: ['/iri/1', '/iri/2'],
-          nested_array: { nested: ['/nested_iri/1', '/nested_iri/2'] },
-          exists: { foo: true },
-          nested_date: { date: { before: '2000' } },
-          nested_range: { range: { between: '12.99..15.99' } },
-        },
-        searchParams: { pagination: true },
-      })
-      .then(() => {
-        const searchParams = Array.from(
-          mockFetchHydra.mock.calls[0][0].searchParams.entries(),
-        );
-        expect(searchParams[0]).toEqual(['pagination', 'true']);
-        expect(searchParams[1]).toEqual(['simple', 'foo']);
-        expect(searchParams[2]).toEqual(['nested.param', 'bar']);
-        expect(searchParams[3]).toEqual(['sub_nested.sub.param', 'true']);
-        expect(searchParams[4]).toEqual(['array[0]', '/iri/1']);
-        expect(searchParams[5]).toEqual(['array[1]', '/iri/2']);
-        expect(searchParams[6]).toEqual([
-          'nested_array.nested[0]',
-          '/nested_iri/1',
-        ]);
-        expect(searchParams[7]).toEqual([
-          'nested_array.nested[1]',
-          '/nested_iri/2',
-        ]);
-        expect(searchParams[8]).toEqual(['exists[foo]', 'true']);
-        expect(searchParams[9]).toEqual(['nested_date.date[before]', '2000']);
-        expect(searchParams[10]).toEqual([
-          'nested_range.range[between]',
-          '12.99..15.99',
-        ]);
-      });
+  test('React Admin get list with filter parameters and custom search params', async () => {
+    await dataProvider.getList('resource', {
+      pagination: {},
+      sort: {},
+      filter: {
+        simple: 'foo',
+        nested: { param: 'bar' },
+        sub_nested: { sub: { param: true } },
+        array: ['/iri/1', '/iri/2'],
+        nested_array: { nested: ['/nested_iri/1', '/nested_iri/2'] },
+        exists: { foo: true },
+        nested_date: { date: { before: '2000' } },
+        nested_range: { range: { between: '12.99..15.99' } },
+      },
+      searchParams: { pagination: true },
+    });
+    const searchParams = Array.from(
+      mockFetchHydra.mock.calls[0][0].searchParams.entries(),
+    );
+    expect(searchParams[0]).toEqual(['pagination', 'true']);
+    expect(searchParams[1]).toEqual(['simple', 'foo']);
+    expect(searchParams[2]).toEqual(['nested.param', 'bar']);
+    expect(searchParams[3]).toEqual(['sub_nested.sub.param', 'true']);
+    expect(searchParams[4]).toEqual(['array[0]', '/iri/1']);
+    expect(searchParams[5]).toEqual(['array[1]', '/iri/2']);
+    expect(searchParams[6]).toEqual([
+      'nested_array.nested[0]',
+      '/nested_iri/1',
+    ]);
+    expect(searchParams[7]).toEqual([
+      'nested_array.nested[1]',
+      '/nested_iri/2',
+    ]);
+    expect(searchParams[8]).toEqual(['exists[foo]', 'true']);
+    expect(searchParams[9]).toEqual(['nested_date.date[before]', '2000']);
+    expect(searchParams[10]).toEqual([
+      'nested_range.range[between]',
+      '12.99..15.99',
+    ]);
   });
 
   test('React Admin create', async () => {
     await dataProvider.introspect();
-
-    return dataProvider
-      .create('resource', {
-        data: {
-          foo: 'foo',
-          bar: 'baz',
-        },
-      })
-      .then(() => {
-        const url = mockFetchHydra.mock.calls[1][0];
-        expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
-        const options = mockFetchHydra.mock.calls[1][1];
-        expect(options).toHaveProperty('method');
-        expect(options.method).toEqual('POST');
-        expect(options).toHaveProperty('body');
-        expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
-      });
+    await dataProvider.create('resource', {
+      data: {
+        foo: 'foo',
+        bar: 'baz',
+      },
+    });
+    const url = mockFetchHydra.mock.calls[1][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
+    const options = mockFetchHydra.mock.calls[1][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('POST');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
   });
 
   test('React Admin create upload file', async () => {
     await dataProvider.introspect();
 
     const file = new File(['foo'], 'foo.txt');
-    return dataProvider
-      .create('resource', {
-        data: {
-          image: {
-            rawFile: file,
-          },
-          bar: 'baz',
-          array: ['foo', 'dummy'],
-          object: { foo: 'dummy' },
-          date: new Date(Date.UTC(2020, 6, 6, 12)),
+    await dataProvider.create('resource', {
+      data: {
+        image: {
+          rawFile: file,
         },
-      })
-      .then(() => {
-        const url = mockFetchHydra.mock.calls[2][0];
-        expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
-        const options = mockFetchHydra.mock.calls[2][1];
-        expect(options).toHaveProperty('method');
-        expect(options.method).toEqual('POST');
-        expect(options).toHaveProperty('body');
-        expect(options.body).toBeInstanceOf(FormData);
-        expect(Array.from(options.body.entries())).toEqual([
-          ['image', file],
-          ['bar', 'baz'],
-          ['array', '["foo","dummy"]'],
-          ['object', '{"foo":"dummy"}'],
-          ['date', '2020-07-06T12:00:00.000Z'],
-        ]);
-      });
+        bar: 'baz',
+        array: ['foo', 'dummy'],
+        object: { foo: 'dummy' },
+        date: new Date(Date.UTC(2020, 6, 6, 12)),
+      },
+    });
+    const url = mockFetchHydra.mock.calls[2][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
+    const options = mockFetchHydra.mock.calls[2][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('POST');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toBeInstanceOf(FormData);
+    expect(Array.from(options.body.entries())).toEqual([
+      ['image', file],
+      ['bar', 'baz'],
+      ['array', '["foo","dummy"]'],
+      ['object', '{"foo":"dummy"}'],
+      ['date', '2020-07-06T12:00:00.000Z'],
+    ]);
   });
 
   test('React Admin create multipart override', async () => {
     await dataProvider.introspect();
-
-    return dataProvider
-      .create('resource', {
-        data: {
-          bar: 'baz',
-          foo: 'foo',
-          formEnctype: 'multipart/form-data',
-        },
-      })
-      .then(() => {
-        const url = mockFetchHydra.mock.calls[3][0];
-        expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
-        const options = mockFetchHydra.mock.calls[3][1];
-        expect(options).toHaveProperty('method');
-        expect(options.method).toEqual('POST');
-        expect(options).toHaveProperty('body');
-        expect(options.body).toBeInstanceOf(FormData);
-        expect(Array.from(options.body.entries())).toEqual([
-          ['bar', 'baz'],
-          ['foo', 'foo'],
-        ]);
-      });
+    await dataProvider.create('resource', {
+      data: {
+        bar: 'baz',
+        foo: 'foo',
+        formEnctype: 'multipart/form-data',
+      },
+    });
+    const url = mockFetchHydra.mock.calls[3][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource');
+    const options = mockFetchHydra.mock.calls[3][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('POST');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toBeInstanceOf(FormData);
+    expect(Array.from(options.body.entries())).toEqual([
+      ['bar', 'baz'],
+      ['foo', 'foo'],
+    ]);
   });
 
   test('React Admin update', async () => {
     await dataProvider.introspect();
-
-    return dataProvider
-      .update('resource', {
-        id: '/entrypoint/resource/1',
-        data: {
-          foo: 'foo',
-          bar: 'baz',
-        },
-      })
-      .then(() => {
-        const url = mockFetchHydra.mock.calls[4][0];
-        expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual(
-          'http://localhost/entrypoint/resource/1',
-        );
-        const options = mockFetchHydra.mock.calls[4][1];
-        expect(options).toHaveProperty('method');
-        expect(options.method).toEqual('PUT');
-        expect(options).toHaveProperty('body');
-        expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
-      });
+    await dataProvider.update('resource', {
+      id: '/entrypoint/resource/1',
+      data: {
+        foo: 'foo',
+        bar: 'baz',
+      },
+    });
+    const url = mockFetchHydra.mock.calls[4][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+    const options = mockFetchHydra.mock.calls[4][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('PUT');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toEqual('{"foo":"foo","bar":"baz"}');
   });
 
   test('React Admin update enctype override', async () => {
     await dataProvider.introspect();
-
-    return dataProvider
-      .update('resource', {
-        id: '/entrypoint/resource/1',
-        data: {
-          foo: 'foo',
-          bar: 'baz',
-          formEnctype: 'multipart/form-data',
-        },
-      })
-      .then(() => {
-        const url = mockFetchHydra.mock.calls[5][0];
-        expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual(
-          'http://localhost/entrypoint/resource/1',
-        );
-        const options = mockFetchHydra.mock.calls[5][1];
-        expect(options).toHaveProperty('method');
-        expect(options.method).toEqual('PUT');
-        expect(options).toHaveProperty('body');
-        expect(options.body).toBeInstanceOf(FormData);
-        expect(Array.from(options.body.entries())).toEqual([
-          ['foo', 'foo'],
-          ['bar', 'baz'],
-        ]);
-      });
+    await dataProvider.update('resource', {
+      id: '/entrypoint/resource/1',
+      data: {
+        foo: 'foo',
+        bar: 'baz',
+        formEnctype: 'multipart/form-data',
+      },
+    });
+    const url = mockFetchHydra.mock.calls[5][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+    const options = mockFetchHydra.mock.calls[5][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('PUT');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toBeInstanceOf(FormData);
+    expect(Array.from(options.body.entries())).toEqual([
+      ['foo', 'foo'],
+      ['bar', 'baz'],
+    ]);
   });
 
   test('React Admin update enctype and method override', async () => {
     await dataProvider.introspect();
-
-    return dataProvider
-      .update('resource', {
-        id: '/entrypoint/resource/1',
-        data: {
-          foo: 'foo',
-          bar: 'baz',
-          formEnctype: 'multipart/form-data',
-          formMethod: 'POST',
-        },
-      })
-      .then(() => {
-        const url = mockFetchHydra.mock.calls[6][0];
-        expect(url).toBeInstanceOf(URL);
-        expect(url.toString()).toEqual(
-          'http://localhost/entrypoint/resource/1',
-        );
-        const options = mockFetchHydra.mock.calls[6][1];
-        expect(options).toHaveProperty('method');
-        expect(options.method).toEqual('POST');
-        expect(options).toHaveProperty('body');
-        expect(options.body).toBeInstanceOf(FormData);
-        expect(Array.from(options.body.entries())).toEqual([
-          ['foo', 'foo'],
-          ['bar', 'baz'],
-        ]);
-      });
+    await dataProvider.update('resource', {
+      id: '/entrypoint/resource/1',
+      data: {
+        foo: 'foo',
+        bar: 'baz',
+        formEnctype: 'multipart/form-data',
+        formMethod: 'POST',
+      },
+    });
+    const url = mockFetchHydra.mock.calls[6][0];
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toEqual('http://localhost/entrypoint/resource/1');
+    const options = mockFetchHydra.mock.calls[6][1];
+    expect(options).toHaveProperty('method');
+    expect(options.method).toEqual('POST');
+    expect(options).toHaveProperty('body');
+    expect(options.body).toBeInstanceOf(FormData);
+    expect(Array.from(options.body.entries())).toEqual([
+      ['foo', 'foo'],
+      ['bar', 'baz'],
+    ]);
   });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | #387 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
This pull request adds a verification on the data passed to dataProvider to verify if it has a formEnctype value and if it is set to a 'multipart' value. If so, then it encodes the values to FormData instead of JSON. This will allow posting to endpoints expecting multipart/form-data.

Additionally:
 - Always add tests and ensure they pass. - Check
 - Never break backward compatibility (see https://symfony.com/bc). - Check
 - Bug fixes must be submitted against the current stable version branch. - Check
 - Features and deprecations must be submitted against main branch. - Check
 - Legacy code removals go to the main branch. - Check
 - Update CHANGELOG.md file. - Check
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
