### PR TITLE
fix(CreateGuesser, EditGuesser): inputChildren

### DIFF
--- a/src/CreateGuesser.js
+++ b/src/CreateGuesser.js
@@ -67,6 +67,10 @@ export const IntrospectedCreateGuesser = ({
     displayOverrideCode(schema, writableFields);
   }
 
+  if (!Array.isArray(inputChildren)) {
+    inputChildren = [inputChildren];
+  }
+
   const hasFileField = inputChildren.some((child) => child.type === FileInput);
 
   const save = useCallback(

--- a/src/EditGuesser.js
+++ b/src/EditGuesser.js
@@ -71,6 +71,10 @@ export const IntrospectedEditGuesser = ({
     displayOverrideCode(schema, writableFields);
   }
 
+  if (!Array.isArray(inputChildren)) {
+    inputChildren = [inputChildren];
+  }
+
   const hasFileField = inputChildren.some((child) => child.type === FileInput);
 
   const save = useCallback(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

`inputChildren` when it is the only child is an object, putting it in an array solves the problem of using the `some` function.