### PR TITLE
fix(mui): createMuiTheme deprecation for createTheme

### DIFF
--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -9,7 +9,7 @@ import {
   defaultI18nProvider,
 } from 'react-admin';
 import { createHashHistory } from 'history';
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme as createMuiTheme } from '@material-ui/core';
 
 import ErrorBoundary from './ErrorBoundary';
 import IntrospectionContext from './IntrospectionContext';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | stable
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fix MUI warning on `@api-platform/admin` app launch about `createMuiTheme` usage:

```
Material-UI: the createMuiTheme function was renamed to createTheme.

You should use `import { createTheme } from '@material-ui/core/styles'
```
