### PR TITLE
fix(dataprovider): do not add properties with null value in FormData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.6.8
 
-* Make sure a property's value is not null before check if there is a `toJSON` property in a form data value
+* Make sure a property's value is not null before checking if there is a `toJSON` property in a form data value
 
 ## 2.6.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.8
+
+* Make sure a property's value is not null before check if there is a `toJSON` property in a form data value
+
 ## 2.6.7
 
 * Always use an array for `inputChildren` in guessers

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -201,7 +201,7 @@ export default (
             Object.values(value).find((value) => value instanceof File),
           );
         }
-        if ('function' === typeof value.toJSON) {
+        if (value && 'function' === typeof value.toJSON) {
           return body.append(key, value.toJSON());
         }
         if (isPlainObject(value) || Array.isArray(value)) {

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -187,6 +187,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
           rawFile: file,
         },
         bar: 'baz',
+        qux: null,
         array: ['foo', 'dummy'],
         object: { foo: 'dummy' },
         date: new Date(Date.UTC(2020, 6, 6, 12)),
@@ -203,6 +204,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
     expect(Array.from(options.body.entries())).toEqual([
       ['image', file],
       ['bar', 'baz'],
+      ['qux', 'null'],
       ['array', '["foo","dummy"]'],
       ['object', '{"foo":"dummy"}'],
       ['date', '2020-07-06T12:00:00.000Z'],
@@ -260,6 +262,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
       data: {
         foo: 'foo',
         bar: 'baz',
+        qux: null,
         extraInformation: {
           hasFileField: true,
         },
@@ -276,6 +279,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
     expect(Array.from(options.body.entries())).toEqual([
       ['foo', 'foo'],
       ['bar', 'baz'],
+      ['qux', 'null'],
     ]);
   });
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  main
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fix `TypeError: Cannot read properties of null (reading 'toJSON')`.

When selecting an empty value from a react-admin field that allow null value like ReferenceInput, the error occurs when submitting the form that contain a file field where a FormData is used when convert react-admin data to hydra data because the `toJSON` function cannot be applied on a null value.
