### PR TITLE
feat: add possibility to pass admin component as a prop

### DIFF
--- a/src/AdminGuesser.js
+++ b/src/AdminGuesser.js
@@ -39,6 +39,7 @@ export const AdminResourcesGuesser = ({
   // Admin props
   customReducers = {},
   loadingPage: LoadingPage = Loading,
+  admin: AdminEl = Admin,
   // Props
   children,
   includeDeprecated,
@@ -62,12 +63,12 @@ export const AdminResourcesGuesser = ({
   }
 
   return (
-    <Admin
+    <AdminEl
       customReducers={{ introspect: introspectReducer, ...customReducers }}
       loading={LoadingPage}
       {...rest}>
       {resourceChildren}
-    </Admin>
+    </AdminEl>
   );
 };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | [Admin component props](https://github.com/api-platform/admin/issues/403)
| License       | MIT

Add possibility to pass Admin component as a prop and use for example enterprise version of react-admin