### PR TITLE
feat: mercure support

### DIFF
--- a/src/EditGuesser.js
+++ b/src/EditGuesser.js
@@ -10,6 +10,7 @@ import {
 } from 'react-admin';
 import InputGuesser from './InputGuesser';
 import Introspecter from './Introspecter';
+import useMercureSubscription from './useMercureSubscription';
 
 const displayOverrideCode = (schema, fields) => {
   if (process.env.NODE_ENV === 'production') return;
@@ -59,6 +60,8 @@ export const IntrospectedEditGuesser = ({
   children,
   ...props
 }) => {
+  useMercureSubscription(resource, id);
+
   const [mutate] = useMutation();
   const notify = useNotify();
   const redirect = useRedirect();

--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -33,7 +33,7 @@ const displayOverrideCode = (schema, fields) => {
   console.info(code);
 };
 
-export const DatagridBodyWithMercureSubs = (props) => {
+export const DatagridBodyWithMercure = (props) => {
   useMercureSubscription(props.resource, props.ids);
 
   return <DatagridBody {...props} />;
@@ -48,7 +48,7 @@ export const IntrospectedListGuesser = ({
   rowClick,
   rowStyle,
   isRowSelectable,
-  body = DatagridBodyWithMercureSubs,
+  body = DatagridBodyWithMercure,
   expand,
   optimized,
   children,

--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Datagrid, List, EditButton, ShowButton, DatagridBody } from 'react-admin';
+import {
+  Datagrid,
+  List,
+  EditButton,
+  ShowButton,
+  DatagridBody,
+} from 'react-admin';
 import FieldGuesser from './FieldGuesser';
 import FilterGuesser from './FilterGuesser';
 import Introspecter from './Introspecter';

--- a/src/ListGuesser.js
+++ b/src/ListGuesser.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Datagrid, List, EditButton, ShowButton } from 'react-admin';
+import { Datagrid, List, EditButton, ShowButton, DatagridBody } from 'react-admin';
 import FieldGuesser from './FieldGuesser';
 import FilterGuesser from './FilterGuesser';
 import Introspecter from './Introspecter';
 import Pagination from './list/Pagination';
+import useMercureSubscription from './useMercureSubscription';
 
 const displayOverrideCode = (schema, fields) => {
   if (process.env.NODE_ENV === 'production') return;
@@ -26,6 +27,12 @@ const displayOverrideCode = (schema, fields) => {
   console.info(code);
 };
 
+export const DatagridBodyWithMercureSubs = (props) => {
+  useMercureSubscription(props.resource, props.ids);
+
+  return <DatagridBody {...props} />;
+};
+
 export const IntrospectedListGuesser = ({
   fields,
   readableFields,
@@ -35,7 +42,7 @@ export const IntrospectedListGuesser = ({
   rowClick,
   rowStyle,
   isRowSelectable,
-  body,
+  body = DatagridBodyWithMercureSubs,
   expand,
   optimized,
   children,

--- a/src/ShowGuesser.js
+++ b/src/ShowGuesser.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Show, SimpleShowLayout } from 'react-admin';
 import FieldGuesser from './FieldGuesser';
 import Introspecter from './Introspecter';
+import useMercureSubscription from './useMercureSubscription';
 
 const displayOverrideCode = (schema, fields) => {
   if (process.env.NODE_ENV === 'production') return;
@@ -40,6 +41,8 @@ export const IntrospectedShowGuesser = ({
     ));
     displayOverrideCode(schema, readableFields);
   }
+
+  useMercureSubscription(props.resource, props.id);
 
   return (
     <Show {...props}>

--- a/src/ShowGuesser.test.js
+++ b/src/ShowGuesser.test.js
@@ -6,6 +6,8 @@ import FieldGuesser from './FieldGuesser';
 import { API_FIELDS_DATA } from './__fixtures__/parsedData';
 import { IntrospectedShowGuesser } from './ShowGuesser';
 
+jest.mock('./useMercureSubscription');
+
 describe('<ShowGuesser />', () => {
   test('renders with no children', () => {
     const wrapper = shallow(

--- a/src/hydra/HydraAdmin.js
+++ b/src/hydra/HydraAdmin.js
@@ -9,7 +9,8 @@ const hydraSchemaAnalyzer = schemaAnalyzer();
 
 const HydraAdmin = ({
   entrypoint,
-  dataProvider = dataProviderFactory(entrypoint),
+  mercureHub,
+  dataProvider = dataProviderFactory(entrypoint, mercureHub),
   schemaAnalyzer = hydraSchemaAnalyzer,
   ...props
 }) => (

--- a/src/hydra/HydraAdmin.js
+++ b/src/hydra/HydraAdmin.js
@@ -9,8 +9,11 @@ const hydraSchemaAnalyzer = schemaAnalyzer();
 
 const HydraAdmin = ({
   entrypoint,
-  mercureHub,
-  dataProvider = dataProviderFactory({ entrypoint, mercureHub }),
+  mercure,
+  dataProvider = dataProviderFactory({
+    entrypoint,
+    mercure,
+  }),
   schemaAnalyzer = hydraSchemaAnalyzer,
   ...props
 }) => (

--- a/src/hydra/HydraAdmin.js
+++ b/src/hydra/HydraAdmin.js
@@ -10,7 +10,7 @@ const hydraSchemaAnalyzer = schemaAnalyzer();
 const HydraAdmin = ({
   entrypoint,
   mercureHub,
-  dataProvider = dataProviderFactory(entrypoint, mercureHub),
+  dataProvider = dataProviderFactory({ entrypoint, mercureHub }),
   schemaAnalyzer = hydraSchemaAnalyzer,
   ...props
 }) => (

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -599,7 +599,7 @@ export default (
     subscribe: (resourceIds, callback) => {
       if (!mercure || !mercure.hub) {
         throw new Error(
-          'Mercure URL not set, did you forget to pass a `mercure` configuration to `HydraAdmin`?',
+          'Mercure hub URL not set, did you forget to pass a mercure configuration to the Hydra data provider?',
         );
       }
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -127,20 +127,20 @@ export default (
   let mercure;
   let entrypoint = entrypointOrParams;
   if (typeof entrypointOrParams === 'object') {
-    const params = Object.assign({}, defaultParams, entrypointOrParams);
+    const params = {
+      ...defaultParams,
+      ...entrypointOrParams,
+    };
     entrypoint = params.entrypoint;
     httpClient = params.httpClient;
     apiDocumentationParser = params.apiDocumentationParser;
     useEmbedded = params.useEmbedded;
-    mercure = Object.assign(
-      {},
-      {
-        hub: `${params.entrypoint}/.well-known/mercure`,
-        jwt: null,
-        topicUrl: window.origin,
-      },
-      params.mercure,
-    );
+    mercure = {
+      hub: `${params.entrypoint}/.well-known/mercure`,
+      jwt: null,
+      topicUrl: window.origin,
+      ...params.mercure,
+    };
   } else {
     console.warn(
       'Passing a list of arguments is deprecated! Use an object instead.',

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -640,13 +640,15 @@ export default (
     unsubscribe: (resource, resourceIds) => {
       resourceIds.forEach((resourceId) => {
         const sub = subscriptions[resourceId];
-        if (sub !== undefined) {
-          sub.count--;
+        if (sub === undefined) {
+          return;
+        }
 
-          if (sub.count <= 0) {
-            sub.eventSource.removeEventListener('message', sub.eventListener);
-            delete subscriptions[resourceId];
-          }
+        sub.count--;
+
+        if (sub.count <= 0) {
+          sub.eventSource.removeEventListener('message', sub.eventListener);
+          delete subscriptions[resourceId];
         }
       });
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -568,29 +568,31 @@ export default (
                   (status ? `Status: ${status}` : ''),
               );
             }),
-    subscribe: (resourceID, callback) => {
-      if (!subscriptions.find((sub) => sub.id === resourceID)) {
-        const url = new URL(mercureHub, window.origin);
-        url.searchParams.append(
-          'topic',
-          new URL(resourceID, entrypoint).toString(),
-        );
-        const eventSource = new EventSource(url.toString());
-        eventSource.addEventListener('message', (event) => {
-          const document = transformJsonLdDocumentToReactAdminDocument(
-            JSON.parse(event.data),
+    subscribe: (resourceIDs, callback) => {
+      resourceIDs.forEach((resourceID) => {
+        if (!subscriptions.find((sub) => sub.id === resourceID)) {
+          const url = new URL(mercureHub, window.origin);
+          url.searchParams.append(
+            'topic',
+            new URL(resourceID, entrypoint).toString(),
           );
-          // we need redux's `dispatch` from the react tree
-          callback(document);
-        });
+          const eventSource = new EventSource(url.toString());
+          eventSource.addEventListener('message', (event) => {
+            const document = transformJsonLdDocumentToReactAdminDocument(
+              JSON.parse(event.data),
+            );
+            // we need redux's `dispatch` from the react tree
+            callback(document);
+          });
 
-        subscriptions.push({ id: resourceID, eventSource });
-      }
+          subscriptions.push({ id: resourceID, eventSource });
+        }
+      });
 
       return Promise.resolve({ data: null });
     },
-    unsubscribe: (resource, resourceID) => {
-      subscriptions.filter((sub) => sub.id !== resourceID);
+    unsubscribe: (resource, resourceIDs) => {
+      subscriptions.filter((sub) => !resourceIDs.includes(sub.id));
       return Promise.resolve({ data: null });
     },
   };

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -141,6 +141,10 @@ export default (
       },
       params.mercure,
     );
+  } else {
+    console.warn(
+      'Passing a list of arguments is deprecated! Use an object instead.',
+    );
   }
 
   /** @type {Api} */

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -114,12 +114,16 @@ export const transformJsonLdDocumentToReactAdminDocument = (
  */
 export default (
   entrypoint,
+  mercureHub = `${entrypoint}/.well-known/mercure`,
   httpClient = fetchHydra,
   apiDocumentationParser = parseHydraDocumentation,
   useEmbedded = false, // remove this parameter for 3.0 (as true)
 ) => {
   /** @type {Api} */
   let apiSchema;
+
+  // store mercure subscriptions
+  const subscriptions = [];
 
   /**
    * @param {Resource} resource
@@ -564,5 +568,30 @@ export default (
                   (status ? `Status: ${status}` : ''),
               );
             }),
+    subscribe: (resourceID, callback) => {
+      if (!subscriptions.find((sub) => sub.id === resourceID)) {
+        const url = new URL(mercureHub, window.origin);
+        url.searchParams.append(
+          'topic',
+          new URL(resourceID, entrypoint).toString(),
+        );
+        const eventSource = new EventSource(url.toString());
+        eventSource.addEventListener('message', (event) => {
+          const document = transformJsonLdDocumentToReactAdminDocument(
+            JSON.parse(event.data),
+          );
+          // we need redux's `dispatch` from the react tree
+          callback(document);
+        });
+
+        subscriptions.push({ id: resourceID, eventSource });
+      }
+
+      return Promise.resolve({ data: null });
+    },
+    unsubscribe: (resource, resourceID) => {
+      subscriptions.filter((sub) => sub.id !== resourceID);
+      return Promise.resolve({ data: null });
+    },
   };
 };

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -568,9 +568,9 @@ export default (
                   (status ? `Status: ${status}` : ''),
               );
             }),
-    subscribe: (resourceIDs, callback) => {
-      resourceIDs.forEach((resourceID) => {
-        const sub = subscriptions.find((sub) => sub.id === resourceID);
+    subscribe: (resourceIds, callback) => {
+      resourceIds.forEach((resourceId) => {
+        const sub = subscriptions.find((sub) => sub.id === resourceId);
         if (sub != null) {
           sub.count++;
           return;
@@ -579,7 +579,7 @@ export default (
         const url = new URL(mercureHub, window.origin);
         url.searchParams.append(
           'topic',
-          new URL(resourceID, entrypoint).toString(),
+          new URL(resourceId, entrypoint).toString(),
         );
         const eventSource = new EventSource(url.toString());
         const eventListener = (event) => {
@@ -592,7 +592,7 @@ export default (
         eventSource.addEventListener('message', eventListener);
 
         subscriptions.push({
-          id: resourceID,
+          id: resourceId,
           eventSource,
           eventListener,
           count: 1,
@@ -601,9 +601,9 @@ export default (
 
       return Promise.resolve({ data: null });
     },
-    unsubscribe: (resource, resourceIDs) => {
+    unsubscribe: (resource, resourceIds) => {
       subscriptions.filter((sub) => {
-        if (resourceIDs.includes(sub.id)) {
+        if (resourceIds.includes(sub.id)) {
           sub.count--;
           if (sub.count <= 0) {
             sub.eventSource.removeEventListener('message', sub.eventListener);

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -586,7 +586,7 @@ export default (
           const document = transformJsonLdDocumentToReactAdminDocument(
             JSON.parse(event.data),
           );
-          // we need redux's `dispatch` from the react tree
+          // the only need for this callback is for accessing redux's `dispatch` method to update RA's state.
           callback(document);
         };
         eventSource.addEventListener('message', eventListener);

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -143,7 +143,7 @@ export default (
     };
   } else {
     console.warn(
-      'Passing a list of arguments is deprecated! Use an object instead.',
+      'Passing a list of arguments for building the data provider is deprecated. Please use an object instead.',
     );
   }
 

--- a/src/hydra/dataProvider.js
+++ b/src/hydra/dataProvider.js
@@ -99,6 +99,12 @@ export const transformJsonLdDocumentToReactAdminDocument = (
   return document;
 };
 
+const defaultParams = {
+  httpClient: fetchHydra,
+  apiDocumentationParser: parseHydraDocumentation,
+  useEmbedded: false,
+};
+
 /**
  * Maps react-admin queries to a Hydra powered REST API
  *
@@ -113,12 +119,24 @@ export const transformJsonLdDocumentToReactAdminDocument = (
  * UPDATE   => PUT http://my.api.url/posts/123
  */
 export default (
-  entrypoint,
-  mercureHub = `${entrypoint}/.well-known/mercure`,
+  entrypointOrParams,
   httpClient = fetchHydra,
   apiDocumentationParser = parseHydraDocumentation,
   useEmbedded = false, // remove this parameter for 3.0 (as true)
 ) => {
+  let mercureHub;
+  let entrypoint = entrypointOrParams;
+  if (typeof entrypointOrParams === 'object') {
+    const params = Object.assign({}, defaultParams, entrypointOrParams);
+    entrypoint = params.entrypoint;
+    httpClient = params.httpClient;
+    apiDocumentationParser = params.apiDocumentationParser;
+    useEmbedded = params.useEmbedded;
+    mercureHub =
+      entrypointOrParams.mercureHub ||
+      `${entrypointOrParams.entrypoint}/.well-known/mercure`;
+  }
+
   /** @type {Api} */
   let apiSchema;
 

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -114,6 +114,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
   );
   const dataProvider = dataProviderFactory(
     'entrypoint',
+    'entrypoint',
     mockFetchHydra,
     mockApiDocumentationParser,
   );

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -112,12 +112,12 @@ describe('Transform a React Admin request to an Hydra request', () => {
       }),
     }),
   );
-  const dataProvider = dataProviderFactory(
-    'entrypoint',
-    'entrypoint',
-    mockFetchHydra,
-    mockApiDocumentationParser,
-  );
+  const dataProvider = dataProviderFactory({
+    entrypoint: 'entrypoint',
+    mercureHub: 'entrypoint',
+    httpClient: mockFetchHydra,
+    apiDocumentationParser: mockApiDocumentationParser,
+  });
 
   test('React Admin get list with filter parameters and custom search params', async () => {
     await dataProvider.getList('resource', {

--- a/src/hydra/dataProvider.test.js
+++ b/src/hydra/dataProvider.test.js
@@ -114,7 +114,9 @@ describe('Transform a React Admin request to an Hydra request', () => {
   );
   const dataProvider = dataProviderFactory({
     entrypoint: 'entrypoint',
-    mercureHub: 'entrypoint',
+    mercure: {
+      hub: 'entrypoint',
+    },
     httpClient: mockFetchHydra,
     apiDocumentationParser: mockApiDocumentationParser,
   });

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -17,9 +17,9 @@ export default function useMercureSubscription(resource, idOrIds) {
     const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
 
     if (
-      (!didShowNoSubscribeMethodWarning.current &&
-        dataProvider.subscribe === undefined) ||
-      dataProvider.unsubscribe === undefined
+      !didShowNoSubscribeMethodWarning.current &&
+        (dataProvider.subscribe === undefined ||
+      dataProvider.unsubscribe === undefined)
     ) {
       console.warn(
         'subscribe and/or unsubscribe methods were not set in the data provider, Mercure realtime update functionalities will not work. Please use a compatible data provider.',

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -1,0 +1,33 @@
+import {
+  CRUD_GET_ONE_SUCCESS,
+  FETCH_END,
+  GET_ONE,
+  useDataProvider,
+} from 'ra-core';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+export default function useMercureSubscription(resource, id) {
+  const dataProvider = useDataProvider();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dataProvider.subscribe(id, (document) => {
+      dispatch({
+        type: CRUD_GET_ONE_SUCCESS,
+        payload: {
+          data: document,
+        },
+        meta: {
+          resource,
+          fetchResponse: GET_ONE,
+          fetchStatus: FETCH_END,
+        },
+      });
+    });
+
+    return () => {
+      dataProvider.unsubscribe(resource, id);
+    };
+  }, [id, resource, dataProvider, dispatch]);
+}

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -11,20 +11,20 @@ export default function useMercureSubscription(resource, idOrIds) {
   const dataProvider = useDataProvider();
   const dispatch = useDispatch();
 
-  const didShowNoSubscribeMethodWarning = useRef(false);
+  const hasShownNoSubscribeWarning = useRef(false);
 
   useEffect(() => {
     const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
 
     if (
-      !didShowNoSubscribeMethodWarning.current &&
+      !hasShownNoSubscribeWarning.current &&
       (dataProvider.subscribe === undefined ||
         dataProvider.unsubscribe === undefined)
     ) {
       console.warn(
         'subscribe and/or unsubscribe methods were not set in the data provider, Mercure realtime update functionalities will not work. Please use a compatible data provider.',
       );
-      didShowNoSubscribeMethodWarning.current = true;
+      hasShownNoSubscribeWarning.current = true;
       return;
     }
 

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -19,7 +19,7 @@ export default function useMercureSubscription(resource, idOrIds) {
       dataProvider.unsubscribe === undefined
     ) {
       console.warn(
-        '`subscribe` and/or `unsubcribe` methods were not set in the `dataProvider`, mercure realtime update functionnalities will not work',
+        'subscribe and/or unsubscribe methods were not set in the data provider, Mercure realtime update functionalities will not work. Please use a compatible data provider.',
       );
       return;
     }

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -13,6 +13,17 @@ export default function useMercureSubscription(resource, idOrIds) {
 
   useEffect(() => {
     const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+
+    if (
+      dataProvider.subscribe === undefined ||
+      dataProvider.unsubscribe === undefined
+    ) {
+      console.warn(
+        '`subscribe` and/or `unsubcribe` methods were not set in the `dataProvider`, mercure realtime update functionnalities will not work',
+      );
+      return;
+    }
+
     dataProvider.subscribe(ids, (document) => {
       dispatch({
         type: CRUD_GET_ONE_SUCCESS,

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -7,12 +7,13 @@ import {
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
-export default function useMercureSubscription(resource, id) {
+export default function useMercureSubscription(resource, idOrIds) {
   const dataProvider = useDataProvider();
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dataProvider.subscribe(id, (document) => {
+    const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+    dataProvider.subscribe(ids, (document) => {
       dispatch({
         type: CRUD_GET_ONE_SUCCESS,
         payload: {
@@ -27,7 +28,7 @@ export default function useMercureSubscription(resource, id) {
     });
 
     return () => {
-      dataProvider.unsubscribe(resource, id);
+      dataProvider.unsubscribe(resource, ids);
     };
-  }, [id, resource, dataProvider, dispatch]);
+  }, [idOrIds, resource, dataProvider, dispatch]);
 }

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -4,23 +4,27 @@ import {
   GET_ONE,
   useDataProvider,
 } from 'ra-core';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
 export default function useMercureSubscription(resource, idOrIds) {
   const dataProvider = useDataProvider();
   const dispatch = useDispatch();
 
+  const didShowNoSubscribeMethodWarning = useRef(false);
+
   useEffect(() => {
     const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
 
     if (
-      dataProvider.subscribe === undefined ||
+      (!didShowNoSubscribeMethodWarning.current &&
+        dataProvider.subscribe === undefined) ||
       dataProvider.unsubscribe === undefined
     ) {
       console.warn(
         'subscribe and/or unsubscribe methods were not set in the data provider, Mercure realtime update functionalities will not work. Please use a compatible data provider.',
       );
+      didShowNoSubscribeMethodWarning.current = true;
       return;
     }
 

--- a/src/useMercureSubscription.js
+++ b/src/useMercureSubscription.js
@@ -18,8 +18,8 @@ export default function useMercureSubscription(resource, idOrIds) {
 
     if (
       !didShowNoSubscribeMethodWarning.current &&
-        (dataProvider.subscribe === undefined ||
-      dataProvider.unsubscribe === undefined)
+      (dataProvider.subscribe === undefined ||
+        dataProvider.unsubscribe === undefined)
     ) {
       console.warn(
         'subscribe and/or unsubscribe methods were not set in the data provider, Mercure realtime update functionalities will not work. Please use a compatible data provider.',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #144 
| License       | MIT
| Doc PR        | api-platform/docs#1471

Add built-in mercure support for AP's admin.

Adds a hook which can be added to any component. The hook will subscribe to the passed resource, update react-admin's store on update (using RA's actions dispatched on a successful `getOne`) and cleanup on unmount.

Adds a new optional prop to `HydraAdmin` which can be used to customize the mercure endpoint.

- [x] Show
- [x] List
- [x] Edit
- [x] Fix components tests
- [x] Doc
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
