### PR TITLE
feat: add rimraf for cleaner build

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-redux": "^7.1.0",
     "react-test-renderer": "^17.0.0",
     "redux": "^3.7.0 || ^4.0.0",
+    "rimraf": "^3.0.2",
     "ts-jest": "^27.1.0",
     "typescript": "^4.5.0"
   },
@@ -59,14 +60,14 @@
     "react-dom": "^16.9.0 || ^17.0.0"
   },
   "scripts": {
-    "build": "babel src -d lib --extensions .ts,.tsx --ignore '*.test.js'",
+    "build": "rimraf ./lib && babel src -d lib --extensions .ts,.tsx --ignore '*.test.js'",
     "eslint-check": "eslint-config-prettier .eslintrc.js",
     "fix": "eslint --ignore-pattern 'lib/*' --ext .ts,.tsx,.js,.md --fix .",
     "lint": "eslint --ignore-pattern 'lib/*' --ext .ts,.tsx,.js,.md .",
     "test": "jest src",
     "test:types": "tsc",
     "test:watch": "jest --watch src",
-    "watch": "babel src -d lib --extensions .ts,.tsx --ignore '*.test.js' --watch"
+    "watch": "rimraf ./lib && babel src -d lib --extensions .ts,.tsx --ignore '*.test.js' --watch"
   },
   "jest": {
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-redux": "^7.1.0",
     "react-test-renderer": "^17.0.0",
     "redux": "^3.7.0 || ^4.0.0",
-    "rimraf": "^3.0.2",
+    "rimraf": "^3.0.0",
     "ts-jest": "^27.1.0",
     "typescript": "^4.5.0"
   },


### PR DESCRIPTION
Improves DX by assuring that the `/lib` folder generated is fresh and don't have any other files from previous build

Avoid to have to manually do `rm -rf ./lib`