### PR TITLE
fix: Close event source connections

### DIFF
--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -806,6 +806,7 @@ function dataProvider(
         if (sub.count <= 0) {
           if (sub.subscribed && sub.eventSource && sub.eventListener) {
             sub.eventSource.removeEventListener('message', sub.eventListener);
+            sub.eventSource.close();
           }
           delete subscriptions[resourceId];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | https://github.com/api-platform/admin/issues/413
| License       | MIT

As mentioned in the issue, the SSE streams for the Mercure feature are not closed before setting up new ones on rendering the page. That produces issues in the browser as there will be too many of them open (but not used) after a few user actions, leading to an unresponsive UI.

This change simply closes the streams.