### PR TITLE
feat: add OpenAPI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+
+* Add full OpenAPI support (introduce `OpenApiAdmin`)
+
 ## 3.0.2
 
 * Introduce `useDisplayOverrideCode` hook to avoid displaying the code message if the guesser component is rendered multiple times

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![npm version](https://badge.fury.io/js/%40api-platform%2Fadmin.svg)](https://badge.fury.io/js/%40api-platform%2Fadmin)
 
 API Platform Admin is a tool to automatically create a beautiful (Material Design) and fully-featured administration interface
-for any API supporting [the Hydra Core Vocabulary](http://www.hydra-cg.com/), including but not limited to all APIs created
-using [the API Platform framework](https://api-platform.com).
+for any API supporting [the Hydra Core Vocabulary](http://www.hydra-cg.com/) or exposing an [OpenAPI documentation](https://www.openapis.org/),
+including but not limited to all APIs created using [the API Platform framework](https://api-platform.com).
 
 ![Demo of API Platform Admin in action](https://api-platform.com/97cd2738071d63989db0bbcb6ba85a25/admin-demo.gif)
 
@@ -33,9 +33,15 @@ The source code of the demo is available [in this repository](https://github.com
 ```javascript
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HydraAdmin } from '@api-platform/admin';
+import { HydraAdmin, OpenApiAdmin } from '@api-platform/admin';
 
+// To use Hydra:
 const Admin = () => <HydraAdmin entrypoint="https://demo.api-platform.com" />; // Replace with your own API entrypoint
+// To use OpenAPI (with a very simple REST data provider):
+const Admin = () => <OpenApiAdmin
+  docEntrypoint="https://demo.api-platform.com/docs.json" // Replace with your own OpenAPI documentation entrypoint
+  entrypoint="https://demo.api-platform.com" // Replace with your own API entrypoint
+/>;
 
 ReactDOM.render(<Admin />, document.getElementById('root'));
 ```
@@ -49,13 +55,28 @@ import {
   AdminGuesser,
   hydraDataProvider,
   hydraSchemaAnalyzer,
+  openApiDataProvider,
+  openApiSchemaAnalyzer
 } from '@api-platform/admin';
+import simpleRestProvider from 'ra-data-simple-rest';
+
+// Use your custom data provider or resource schema analyzer
+// Hydra:
+const dataProvider = hydraDataProvider({ entrypoint: 'https://demo.api-platform.com' });
+const schemaAnalyzer = hydraSchemaAnalyzer();
+// OpenAPI:
+const dataProvider = openApiDataProvider({
+  // Use any data provider you like
+  dataProvider: simpleRestProvider('https://demo.api-platform.com'),
+  entrypoint: 'https://demo.api-platform.com',
+  docEntrypoint: 'https://demo.api-platform.com/docs.json',
+});
+const schemaAnalyzer = openApiSchemaAnalyzer();
 
 const Admin = () => (
   <AdminGuesser
-    // Use your custom data provider or resource schema analyzer
-    dataProvider={hydraDataProvider({ entrypoint: 'https://demo.api-platform.com' })}
-    schemaAnalyzer={hydraSchemaAnalyzer()}
+    dataProvider={dataProvider}
+    schemaAnalyzer={schemaAnalyzer}
   />
 );
 
@@ -64,7 +85,7 @@ ReactDOM.render(<Admin />, document.getElementById('root'));
 
 ## Features
 
-* Automatically generates an admin interface for all the resources of the API thanks to hypermedia features of Hydra
+* Automatically generates an admin interface for all the resources of the API thanks to the hypermedia features of Hydra or to the OpenAPI documentation
 * Generates 'list', 'create', 'show', and 'edit' screens, as well as a delete button
 * Generates suitable inputs and fields according to the API doc (e.g. number HTML input for numbers, checkbox for booleans, selectbox for relationships...)
 * Generates suitable inputs and fields according to Schema.org types if available (e.g. email field for `http://schema.org/email`)
@@ -72,7 +93,7 @@ ReactDOM.render(<Admin />, document.getElementById('root'));
 * Supports pagination
 * Supports filters and ordering
 * Automatically validates whether a field is mandatory client-side according to the API description
-* Sends proper HTTP requests to the API and decodes them using Hydra and JSON-LD formats
+* Sends proper HTTP requests to the API and decodes them using Hydra and JSON-LD formats if available
 * Nicely displays server-side errors (e.g. advanced validation)
 * Supports real-time updates with [Mercure](https://mercure.rocks)
 * All the [features provided by React-admin](https://marmelab.com/react-admin/Tutorial.html) can also be used

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@api-platform/api-doc-parser": "^0.13.3",
+    "@api-platform/api-doc-parser": "^0.14.3",
     "history": "^5.0.0",
     "jsonld": "^5.2.0",
     "lodash.isplainobject": "^4.0.6",

--- a/src/dataProvider/adminDataProvider.ts
+++ b/src/dataProvider/adminDataProvider.ts
@@ -1,0 +1,69 @@
+import type { Api, Resource } from '@api-platform/api-doc-parser';
+import { mercureManager } from '../mercure';
+import type {
+  ApiDocumentationParserResponse,
+  ApiPlatformAdminDataProviderFactoryParams,
+  ApiPlatformAdminRecord,
+  MercureOptions,
+} from '../types';
+
+export default (
+  factoryParams: Required<ApiPlatformAdminDataProviderFactoryParams>,
+) => {
+  const { entrypoint, docEntrypoint, apiDocumentationParser } = factoryParams;
+  const mercure: MercureOptions = {
+    hub: null,
+    jwt: null,
+    topicUrl: entrypoint,
+    ...factoryParams.mercure,
+  };
+  mercureManager.setMercureOptions(mercure);
+
+  let apiSchema: Api & { resources: Resource[] };
+
+  return {
+    introspect: (_resource = '', _params = {}) =>
+      apiSchema
+        ? Promise.resolve({ data: apiSchema })
+        : apiDocumentationParser(docEntrypoint)
+            .then(({ api }: ApiDocumentationParserResponse) => {
+              if (api.resources && api.resources.length > 0) {
+                apiSchema = { ...api, resources: api.resources };
+              }
+              return { data: api };
+            })
+            .catch((err) => {
+              const { status, error } = err;
+              let { message } = err;
+              // Note that the `api-doc-parser` rejects with a non-standard error object hence the check
+              if (error?.message) {
+                message = error.message;
+              }
+
+              throw new Error(
+                `Cannot fetch API documentation:\n${
+                  message
+                    ? `${message}\nHave you verified that CORS is correctly configured in your API?\n`
+                    : ''
+                }${status ? `Status: ${status}` : ''}`,
+              );
+            }),
+    subscribe: (
+      resourceIds: string[],
+      callback: (document: ApiPlatformAdminRecord) => void,
+    ) => {
+      resourceIds.forEach((resourceId) => {
+        mercureManager.subscribe(resourceId, resourceId, callback);
+      });
+
+      return Promise.resolve({ data: null });
+    },
+    unsubscribe: (_resource: string, resourceIds: string[]) => {
+      resourceIds.forEach((resourceId) => {
+        mercureManager.unsubscribe(resourceId);
+      });
+
+      return Promise.resolve({ data: null });
+    },
+  };
+};

--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -1,4 +1,5 @@
+import adminDataProvider from './adminDataProvider';
+import restDataProvider from './restDataProvider';
 import useUpdateCache from './useUpdateCache';
 
-// eslint-disable-next-line import/prefer-default-export
-export { useUpdateCache };
+export { adminDataProvider, restDataProvider, useUpdateCache };

--- a/src/dataProvider/restDataProvider.ts
+++ b/src/dataProvider/restDataProvider.ts
@@ -1,0 +1,148 @@
+import { stringify } from 'query-string';
+import { fetchUtils } from 'react-admin';
+import type { DataProvider } from 'react-admin';
+
+// Based on https://github.com/marmelab/react-admin/blob/master/packages/ra-data-simple-rest/src/index.ts
+
+export default (
+  apiUrl: string,
+  httpClient = fetchUtils.fetchJson,
+): DataProvider => ({
+  getList: async (resource, params) => {
+    const { page, perPage } = params.pagination;
+    const { field, order } = params.sort;
+
+    const rangeStart = (page - 1) * perPage;
+    const rangeEnd = page * perPage - 1;
+
+    const query = {
+      sort: JSON.stringify([field, order]),
+      range: JSON.stringify([rangeStart, rangeEnd]),
+      filter: JSON.stringify(params.filter),
+    };
+    const url = `${apiUrl}/${resource}?${stringify(query)}`;
+    const { json } = await httpClient(url);
+
+    return {
+      data: json,
+      pageInfo: {
+        hasNextPage: true,
+        hasPreviousPage: page > 1,
+      },
+    };
+  },
+
+  getOne: async (resource, params) => {
+    const url = `${apiUrl}/${resource}/${params.id}`;
+    const { json } = await httpClient(url);
+
+    return {
+      data: json,
+    };
+  },
+
+  getMany: async (resource, params) => {
+    const query = {
+      filter: JSON.stringify({ id: params.ids }),
+    };
+    const url = `${apiUrl}/${resource}?${stringify(query)}`;
+    const { json } = await httpClient(url);
+
+    return {
+      data: json,
+    };
+  },
+
+  getManyReference: async (resource, params) => {
+    const { page, perPage } = params.pagination;
+    const { field, order } = params.sort;
+
+    const rangeStart = (page - 1) * perPage;
+    const rangeEnd = page * perPage - 1;
+
+    const query = {
+      sort: JSON.stringify([field, order]),
+      range: JSON.stringify([rangeStart, rangeEnd]),
+      filter: JSON.stringify({
+        ...params.filter,
+        [params.target]: params.id,
+      }),
+    };
+    const url = `${apiUrl}/${resource}?${stringify(query)}`;
+    const { json } = await httpClient(url);
+
+    return {
+      data: json,
+      pageInfo: {
+        hasNextPage: true,
+        hasPreviousPage: page > 1,
+      },
+    };
+  },
+
+  update: async (resource, params) => {
+    const url = `${apiUrl}/${resource}/${params.id}`;
+    const { json } = await httpClient(url, {
+      method: 'PUT',
+      body: JSON.stringify(params.data),
+    });
+
+    return {
+      data: json,
+    };
+  },
+
+  updateMany: async (resource, params) => {
+    const responses = await Promise.all(
+      params.ids.map((id) => {
+        const url = `${apiUrl}/${resource}/${id}`;
+
+        return httpClient(url, {
+          method: 'PUT',
+          body: JSON.stringify(params.data),
+        });
+      }),
+    );
+
+    return { data: responses.map(({ json }) => json.id) };
+  },
+
+  create: async (resource, params) => {
+    const url = `${apiUrl}/${resource}`;
+    const { json } = await httpClient(url, {
+      method: 'POST',
+      body: JSON.stringify(params.data),
+    });
+
+    return {
+      data: { ...params.data, id: json.id },
+    };
+  },
+
+  delete: async (resource, params) => {
+    const url = `${apiUrl}/${resource}/${params.id}`;
+    const { json } = await httpClient(url, {
+      method: 'DELETE',
+    });
+
+    return {
+      data: json,
+    };
+  },
+
+  deleteMany: async (resource, params) => {
+    const responses = await Promise.all(
+      params.ids.map((id) => {
+        const url = `${apiUrl}/${resource}/${id}`;
+
+        return httpClient(url, {
+          method: 'DELETE',
+        });
+      }),
+    );
+
+    return {
+      data: responses.map(({ json }) => json.id),
+    };
+  },
+});

--- a/src/hydra/fetchHydra.ts
+++ b/src/hydra/fetchHydra.ts
@@ -6,14 +6,14 @@ import {
 import jsonld from 'jsonld';
 import type { NodeObject } from 'jsonld';
 import type { JsonLdObj } from 'jsonld/jsonld-spec';
-import type { HydraHttpClientOptions, HydraHttpClientResponse } from '../types';
+import type { HttpClientOptions, HydraHttpClientResponse } from '../types';
 
 /**
  * Sends HTTP requests to a Hydra API.
  */
 function fetchHydra(
   url: URL,
-  options: HydraHttpClientOptions = {},
+  options: HttpClientOptions = {},
 ): Promise<HydraHttpClientResponse> {
   let requestHeaders = options.headers ?? new Headers();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,4 +34,10 @@ export {
   fetchHydra,
 } from './hydra';
 export type { HydraAdminProps } from './hydra';
+export {
+  OpenApiAdmin,
+  dataProvider as openApiDataProvider,
+  schemaAnalyzer as openApiSchemaAnalyzer,
+} from './openapi';
+export type { OpenApiAdminProps } from './openapi';
 export * from './types';

--- a/src/mercure/createSubscription.ts
+++ b/src/mercure/createSubscription.ts
@@ -1,0 +1,51 @@
+import type {
+  ApiPlatformAdminRecord,
+  DataTransformer,
+  MercureOptions,
+  MercureSubscription,
+} from '../types';
+
+const createSubscription = (
+  mercure: MercureOptions,
+  topic: string,
+  callback: (document: ApiPlatformAdminRecord) => void,
+  transformData: DataTransformer = (parsedData) =>
+    parsedData as ApiPlatformAdminRecord,
+): MercureSubscription => {
+  if (mercure.hub === null) {
+    return {
+      subscribed: false,
+      topic,
+      callback,
+      count: 1,
+    };
+  }
+
+  const url = new URL(mercure.hub, window.origin);
+  url.searchParams.append('topic', new URL(topic, mercure.topicUrl).toString());
+
+  if (mercure.jwt !== null) {
+    document.cookie = `mercureAuthorization=${mercure.jwt}; Path=${mercure.hub}; Secure; SameSite=None`;
+  }
+
+  const eventSource = new EventSource(url.toString(), {
+    withCredentials: mercure.jwt !== null,
+  });
+  const eventListener = (event: MessageEvent) => {
+    const document = transformData(JSON.parse(event.data));
+    // this callback is for updating RA's state
+    callback(document);
+  };
+  eventSource.addEventListener('message', eventListener);
+
+  return {
+    subscribed: true,
+    topic,
+    callback,
+    eventSource,
+    eventListener,
+    count: 1,
+  };
+};
+
+export default createSubscription;

--- a/src/mercure/index.ts
+++ b/src/mercure/index.ts
@@ -1,0 +1,4 @@
+import createSubscription from './createSubscription';
+import manager from './manager';
+
+export { createSubscription, manager as mercureManager };

--- a/src/mercure/manager.ts
+++ b/src/mercure/manager.ts
@@ -1,0 +1,78 @@
+import createSubscription from './createSubscription';
+import type {
+  ApiPlatformAdminRecord,
+  DataTransformer,
+  MercureOptions,
+  MercureSubscription,
+} from '../types';
+
+// store mercure subscriptions
+const subscriptions: Record<string, MercureSubscription> = {};
+let mercure: MercureOptions = {
+  hub: null,
+  jwt: null,
+  topicUrl: '',
+};
+let dataTransform: DataTransformer = (parsedData) =>
+  parsedData as ApiPlatformAdminRecord;
+
+const stopSubscription = (sub: MercureSubscription) => {
+  if (sub.subscribed && sub.eventSource && sub.eventListener) {
+    sub.eventSource.removeEventListener('message', sub.eventListener);
+    sub.eventSource.close();
+  }
+};
+
+export default {
+  subscribe: (
+    resourceId: string,
+    topic: string,
+    callback: (document: ApiPlatformAdminRecord) => void,
+  ) => {
+    const sub = subscriptions[resourceId];
+    if (sub !== undefined) {
+      sub.count += 1;
+      return;
+    }
+
+    subscriptions[resourceId] = createSubscription(
+      mercure,
+      topic,
+      callback,
+      dataTransform,
+    );
+  },
+  unsubscribe: (resourceId: string) => {
+    const sub = subscriptions[resourceId];
+    if (sub === undefined) {
+      return;
+    }
+
+    sub.count -= 1;
+
+    if (sub.count <= 0) {
+      stopSubscription(sub);
+      delete subscriptions[resourceId];
+    }
+  },
+  initSubscriptions: () => {
+    const subKeys = Object.keys(subscriptions);
+    subKeys.forEach((subKey) => {
+      const sub = subscriptions[subKey];
+      if (sub && !sub.subscribed) {
+        subscriptions[subKey] = createSubscription(
+          mercure,
+          sub.topic,
+          sub.callback,
+          dataTransform,
+        );
+      }
+    });
+  },
+  setMercureOptions: (mercureOptions: MercureOptions) => {
+    mercure = mercureOptions;
+  },
+  setDataTransformer: (dataTransformer: DataTransformer) => {
+    dataTransform = dataTransformer;
+  },
+};

--- a/src/openapi/OpenApiAdmin.tsx
+++ b/src/openapi/OpenApiAdmin.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import dataProviderFactory from './dataProvider';
+import { restDataProvider } from '../dataProvider';
 import /* tree-shaking no-side-effects-when-called */ schemaAnalyzer from './schemaAnalyzer';
 import AdminGuesser from '../AdminGuesser';
 import type { AdminGuesserProps } from '../AdminGuesser';
@@ -12,23 +13,27 @@ type AdminGuesserPartialProps = Omit<
 > &
   Partial<Pick<AdminGuesserProps, 'dataProvider' | 'schemaAnalyzer'>>;
 
-export interface HydraAdminProps extends AdminGuesserPartialProps {
+export interface OpenApiAdminProps extends AdminGuesserPartialProps {
   entrypoint: string;
+  docEntrypoint: string;
   mercure?: MercureOptions;
 }
 
-const hydraSchemaAnalyzer = schemaAnalyzer();
+const openApiSchemaAnalyzer = schemaAnalyzer();
 
-const HydraAdmin = ({
+const OpenApiAdmin = ({
   entrypoint,
+  docEntrypoint,
   mercure,
   dataProvider = dataProviderFactory({
+    dataProvider: restDataProvider(entrypoint),
     entrypoint,
+    docEntrypoint,
     mercure: mercure ?? {},
   }),
-  schemaAnalyzer: adminSchemaAnalyzer = hydraSchemaAnalyzer,
+  schemaAnalyzer: adminSchemaAnalyzer = openApiSchemaAnalyzer,
   ...props
-}: HydraAdminProps) => (
+}: OpenApiAdminProps) => (
   <AdminGuesser
     dataProvider={dataProvider}
     schemaAnalyzer={adminSchemaAnalyzer}
@@ -36,8 +41,8 @@ const HydraAdmin = ({
   />
 );
 
-HydraAdmin.propTypes = {
+OpenApiAdmin.propTypes = {
   entrypoint: PropTypes.string.isRequired,
 };
 
-export default HydraAdmin;
+export default OpenApiAdmin;

--- a/src/openapi/dataProvider.ts
+++ b/src/openapi/dataProvider.ts
@@ -1,0 +1,93 @@
+import { parseOpenApi3Documentation } from '@api-platform/api-doc-parser';
+import { fetchUtils } from 'react-admin';
+import { adminDataProvider } from '../dataProvider';
+import type {
+  ApiPlatformAdminDataProvider,
+  HttpClientOptions,
+  MercureOptions,
+  OpenApiDataProviderFactoryParams,
+} from '../types';
+
+const fetchJson = (url: URL, options: HttpClientOptions = {}) => {
+  let { headers } = options;
+  if (!headers) {
+    headers = {};
+  }
+  headers = typeof headers === 'function' ? headers() : headers;
+  headers = new Headers(headers);
+
+  return fetchUtils.fetchJson(url, { ...options, headers });
+};
+
+const defaultParams: Required<
+  Omit<
+    OpenApiDataProviderFactoryParams,
+    'entrypoint' | 'docEntrypoint' | 'dataProvider'
+  >
+> = {
+  httpClient: fetchJson,
+  apiDocumentationParser: parseOpenApi3Documentation,
+  mercure: {},
+};
+
+function dataProvider(
+  factoryParams: OpenApiDataProviderFactoryParams,
+): ApiPlatformAdminDataProvider {
+  const {
+    dataProvider: {
+      getList,
+      getOne,
+      getMany,
+      getManyReference,
+      update,
+      updateMany,
+      create,
+      delete: deleteFn,
+      deleteMany,
+    },
+    entrypoint,
+    docEntrypoint,
+    httpClient,
+    apiDocumentationParser,
+  }: Required<OpenApiDataProviderFactoryParams> = {
+    ...defaultParams,
+    ...factoryParams,
+  };
+  const mercure: MercureOptions = {
+    hub: null,
+    jwt: null,
+    topicUrl: entrypoint,
+    ...factoryParams.mercure,
+  };
+
+  const { introspect, subscribe, unsubscribe } = adminDataProvider({
+    entrypoint,
+    docEntrypoint,
+    httpClient,
+    apiDocumentationParser,
+    mercure,
+  });
+
+  return {
+    getList,
+    getOne,
+    getMany,
+    getManyReference,
+    update,
+    updateMany,
+    create,
+    delete: deleteFn,
+    deleteMany,
+    introspect,
+    subscribe: (resourceIds, callback) => {
+      if (mercure.hub === null) {
+        return Promise.resolve({ data: null });
+      }
+
+      return subscribe(resourceIds, callback);
+    },
+    unsubscribe,
+  };
+}
+
+export default dataProvider;

--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -1,0 +1,6 @@
+import dataProvider from './dataProvider';
+import OpenApiAdmin from './OpenApiAdmin';
+import type { OpenApiAdminProps } from './OpenApiAdmin';
+import schemaAnalyzer from './schemaAnalyzer';
+
+export { dataProvider, OpenApiAdmin, OpenApiAdminProps, schemaAnalyzer };

--- a/src/openapi/schemaAnalyzer.ts
+++ b/src/openapi/schemaAnalyzer.ts
@@ -1,0 +1,78 @@
+import type { Field, Resource } from '@api-platform/api-doc-parser';
+import {
+  getFiltersParametersFromSchema,
+  getOrderParametersFromSchema,
+} from '../schemaAnalyzer';
+import type { SchemaAnalyzer } from '../types';
+
+/**
+ * @param schema The schema of a resource
+ *
+ * @returns The name of the reference field
+ */
+const getFieldNameFromSchema = (schema: Resource) => {
+  if (!schema.fields || !schema.fields[0]) {
+    return '';
+  }
+
+  if (schema.fields.find((schemaField) => schemaField.name === 'id')) {
+    return 'id';
+  }
+
+  return schema.fields[0].name;
+};
+
+/**
+ * @returns The type of the field
+ */
+const getFieldType = (field: Field) => {
+  switch (field.type) {
+    case 'array':
+      return 'array';
+    case 'string':
+    case 'byte':
+    case 'binary':
+    case 'hexBinary':
+    case 'base64Binary':
+    case 'uuid':
+    case 'password':
+      return 'text';
+    case 'integer':
+    case 'negativeInteger':
+    case 'nonNegativeInteger':
+    case 'positiveInteger':
+    case 'nonPositiveInteger':
+      return 'integer';
+    case 'number':
+    case 'decimal':
+    case 'double':
+    case 'float':
+      return 'float';
+    case 'boolean':
+      return 'boolean';
+    case 'date':
+      return 'date';
+    case 'dateTime':
+    case 'duration':
+    case 'time':
+      return 'dateTime';
+    case 'email':
+      return 'email';
+    case 'url':
+      return 'url';
+    default:
+      return 'text';
+  }
+};
+
+const getSubmissionErrors = () => null;
+
+export default function schemaAnalyzer(): SchemaAnalyzer {
+  return {
+    getFieldNameFromSchema,
+    getOrderParametersFromSchema,
+    getFiltersParametersFromSchema,
+    getFieldType,
+    getSubmissionErrors,
+  };
+}

--- a/src/schemaAnalyzer.ts
+++ b/src/schemaAnalyzer.ts
@@ -1,0 +1,71 @@
+import type { Resource } from '@api-platform/api-doc-parser';
+import type { FilterParameter } from './types';
+
+/**
+ * @param schema The schema of a resource
+ *
+ * @returns The filter parameters
+ */
+export const resolveSchemaParameters = (schema: Resource) => {
+  if (!schema.parameters || !schema.getParameters) {
+    return Promise.resolve([]);
+  }
+
+  return !schema.parameters.length
+    ? schema.getParameters()
+    : Promise.resolve(schema.parameters);
+};
+
+const ORDER_MARKER = 'order[';
+
+/**
+ * @param schema The schema of a resource
+ *
+ * @returns The order filter parameters
+ */
+export const getOrderParametersFromSchema = (
+  schema: Resource,
+): Promise<string[]> => {
+  if (!schema.fields) {
+    return Promise.resolve([]);
+  }
+
+  const authorizedFields = schema.fields.map((field) => field.name);
+  return resolveSchemaParameters(schema).then((parameters) =>
+    parameters
+      .map((filter) => filter.variable)
+      .filter((filter) => filter.includes(ORDER_MARKER))
+      .map((orderFilter) =>
+        orderFilter.replace(ORDER_MARKER, '').replace(']', ''),
+      )
+      .filter((filter) =>
+        authorizedFields.includes(
+          filter.split('.')[0] ?? '', // split to manage nested properties
+        ),
+      ),
+  );
+};
+
+/**
+ * @param schema The schema of a resource
+ *
+ * @returns The filter parameters without the order ones
+ */
+export const getFiltersParametersFromSchema = (
+  schema: Resource,
+): Promise<FilterParameter[]> => {
+  if (!schema.fields) {
+    return Promise.resolve([]);
+  }
+
+  const authorizedFields = schema.fields.map((field) => field.name);
+  return resolveSchemaParameters(schema).then((parameters) =>
+    parameters
+      .map((filter) => ({
+        name: filter.variable,
+        isRequired: filter.required,
+      }))
+      .filter((filter) => !filter.name.includes(ORDER_MARKER))
+      .filter((filter) => authorizedFields.includes(filter.name)),
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,9 @@ export interface ApiPlatformAdminRecord extends RaRecord {
   originId?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DataTransformer = (parsedData: any) => ApiPlatformAdminRecord;
+
 export type Hydra = JsonLdObj | HydraCollection;
 
 export interface HydraView extends JsonLdObj {
@@ -83,7 +86,7 @@ export interface HydraCollection extends JsonLdObj {
   'hydra:view'?: HydraView;
 }
 
-export interface HydraHttpClientOptions {
+export interface HttpClientOptions {
   headers?: HeadersInit | (() => HeadersInit);
   user?: {
     authenticated: boolean;
@@ -91,9 +94,13 @@ export interface HydraHttpClientOptions {
   };
 }
 
-export interface HydraHttpClientResponse {
+export interface HttpClientResponse {
   status: number;
   headers: Headers;
+  json?: unknown;
+}
+
+export interface HydraHttpClientResponse extends HttpClientResponse {
   json?: Hydra;
 }
 
@@ -232,19 +239,34 @@ export type ApiPlatformAdminDataProviderTypeParams<T extends DataProviderType> =
     ? ApiPlatformAdminDeleteManyParams
     : never;
 
-export interface HydraDataProviderFactoryParams {
+export interface ApiPlatformAdminDataProviderFactoryParams {
   entrypoint: string;
+  docEntrypoint?: string;
   httpClient?: (
     url: URL,
-    options?: HydraHttpClientOptions,
-  ) => Promise<HydraHttpClientResponse>;
+    options?: HttpClientOptions,
+  ) => Promise<HttpClientResponse>;
   apiDocumentationParser?: (
     entrypointUrl: string,
     options?: ApiDocumentationParserOptions,
   ) => Promise<ApiDocumentationParserResponse>;
   mercure?: Partial<MercureOptions>;
+}
+
+export interface HydraDataProviderFactoryParams
+  extends ApiPlatformAdminDataProviderFactoryParams {
+  httpClient?: (
+    url: URL,
+    options?: HttpClientOptions,
+  ) => Promise<HydraHttpClientResponse>;
   useEmbedded?: boolean;
   disableCache?: boolean;
+}
+
+export interface OpenApiDataProviderFactoryParams
+  extends ApiPlatformAdminDataProviderFactoryParams {
+  docEntrypoint: string;
+  dataProvider: DataProvider;
 }
 
 export interface ApiPlatformAdminDataProvider extends DataProvider {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fixes #161
| License       | MIT
| Doc PR        | TODO

Add full OpenAPI support.
Introduce `OpenApiAdmin`.
The `openApiDataProvider` needs a `dataProvider` backend to work (see https://marmelab.com/react-admin/DataProviderList.html).
A very simple REST data provider is used by default (no pagination, stringified filters).