### PR TITLE
feat: register the resource with the correct operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+
+* Take the operations into account (list, create, edit, delete)
+
 ## 3.1.1
 
 * Mercure: add back the possibility to use a boolean

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@api-platform/api-doc-parser": "^0.14.3",
+    "@api-platform/api-doc-parser": "^0.15.1",
     "history": "^5.0.0",
     "jsonld": "^5.2.0",
     "lodash.isplainobject": "^4.0.6",
     "prop-types": "^15.6.2",
-    "react-admin": "^4.0.0",
+    "react-admin": "^4.0.3",
     "react-error-boundary": "^3.1.0"
   },
   "devDependencies": {
@@ -46,13 +46,14 @@
     "eslint-plugin-react": "^7.12.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-tree-shaking": "^1.10.0",
-    "jest": "^27.2.0",
+    "jest": "^28.0.0",
+    "jest-environment-jsdom": "^28.1.0",
     "prettier": "^2.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-test-renderer": "^18.0.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^27.1.0",
+    "ts-jest": "^28.0.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.0"
   },

--- a/src/ResourceGuesser.tsx
+++ b/src/ResourceGuesser.tsx
@@ -1,20 +1,77 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Resource } from 'react-admin';
+import { Resource, useResourceDefinitionContext } from 'react-admin';
 import type { ResourceDefinition, ResourceProps } from 'react-admin';
 import ListGuesser from './ListGuesser';
 import CreateGuesser from './CreateGuesser';
 import EditGuesser from './EditGuesser';
 import ShowGuesser from './ShowGuesser';
+import Introspecter from './Introspecter';
+import type {
+  IntrospectedResourceGuesserProps,
+  ResourceGuesserProps,
+} from './types';
 
-const ResourceGuesser = ({
+export const IntrospectedResourceGuesser = ({
+  resource,
+  schema,
+  schemaAnalyzer,
   list = ListGuesser,
   edit = EditGuesser,
   create = CreateGuesser,
   show = ShowGuesser,
   ...props
-}: ResourceProps) => (
-  <Resource {...props} create={create} edit={edit} list={list} show={show} />
+}: IntrospectedResourceGuesserProps) => {
+  const { register } = useResourceDefinitionContext();
+
+  let hasList = false;
+  let hasEdit = false;
+  let hasCreate = false;
+  let hasShow = false;
+  schema.operations?.forEach((operation) => {
+    if (operation.type === 'list') {
+      hasList = true;
+    }
+    if (operation.type === 'edit') {
+      hasEdit = true;
+    }
+    if (operation.type === 'create') {
+      hasCreate = true;
+    }
+    if (operation.type === 'show') {
+      hasShow = true;
+    }
+  });
+  const resourceDefinition: ResourceDefinition = {
+    name: resource,
+    icon: props.icon,
+    options: props.options,
+    hasList,
+    hasEdit,
+    hasCreate,
+    hasShow,
+  };
+
+  register(resourceDefinition);
+
+  return (
+    <Resource
+      {...props}
+      name={resource}
+      create={create}
+      edit={edit}
+      list={list}
+      show={show}
+    />
+  );
+};
+
+const ResourceGuesser = ({ name, ...props }: ResourceGuesserProps) => (
+  <Introspecter
+    component={IntrospectedResourceGuesser}
+    resource={name}
+    {...props}
+  />
 );
 
 ResourceGuesser.raName = 'Resource';

--- a/src/__fixtures__/resources.ts
+++ b/src/__fixtures__/resources.ts
@@ -135,6 +135,7 @@ const resources: Resource[] = [
           operations: [
             {
               name: 'Retrieves the collection of Review resources.',
+              type: 'list',
               method: 'GET',
               returns: 'http://www.w3.org/ns/hydra/core#Collection',
               types: [
@@ -145,6 +146,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Creates a Review resource.',
+              type: 'create',
               method: 'POST',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -156,6 +158,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Retrieves Review resource.',
+              type: 'show',
               method: 'GET',
               returns: 'http://schema.org/Review',
               types: [
@@ -166,6 +169,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Deletes the Review resource.',
+              type: 'delete',
               method: 'DELETE',
               returns: 'http://www.w3.org/2002/07/owl#Nothing',
               types: [
@@ -176,6 +180,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Replaces the Review resource.',
+              type: 'edit',
               method: 'PUT',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -187,6 +192,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Updates the Review resource.',
+              type: 'edit',
               method: 'PATCH',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -332,6 +338,7 @@ const resources: Resource[] = [
           operations: [
             {
               name: 'Retrieves the collection of Review resources.',
+              type: 'list',
               method: 'GET',
               returns: 'http://www.w3.org/ns/hydra/core#Collection',
               types: [
@@ -342,6 +349,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Creates a Review resource.',
+              type: 'create',
               method: 'POST',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -353,6 +361,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Retrieves Review resource.',
+              type: 'show',
               method: 'GET',
               returns: 'http://schema.org/Review',
               types: [
@@ -363,6 +372,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Deletes the Review resource.',
+              type: 'delete',
               method: 'DELETE',
               returns: 'http://www.w3.org/2002/07/owl#Nothing',
               types: [
@@ -373,6 +383,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Replaces the Review resource.',
+              type: 'edit',
               method: 'PUT',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -384,6 +395,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Updates the Review resource.',
+              type: 'edit',
               method: 'PATCH',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -529,6 +541,7 @@ const resources: Resource[] = [
           operations: [
             {
               name: 'Retrieves the collection of Review resources.',
+              type: 'list',
               method: 'GET',
               returns: 'http://www.w3.org/ns/hydra/core#Collection',
               types: [
@@ -539,6 +552,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Creates a Review resource.',
+              type: 'create',
               method: 'POST',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -550,6 +564,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Retrieves Review resource.',
+              type: 'show',
               method: 'GET',
               returns: 'http://schema.org/Review',
               types: [
@@ -560,6 +575,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Deletes the Review resource.',
+              type: 'delete',
               method: 'DELETE',
               returns: 'http://www.w3.org/2002/07/owl#Nothing',
               types: [
@@ -570,6 +586,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Replaces the Review resource.',
+              type: 'edit',
               method: 'PUT',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -581,6 +598,7 @@ const resources: Resource[] = [
             },
             {
               name: 'Updates the Review resource.',
+              type: 'edit',
               method: 'PATCH',
               expects: 'http://schema.org/Review',
               returns: 'http://schema.org/Review',
@@ -600,6 +618,7 @@ const resources: Resource[] = [
     operations: [
       {
         name: 'Retrieves the collection of Book resources.',
+        type: 'list',
         method: 'GET',
         returns: 'http://www.w3.org/ns/hydra/core#Collection',
         types: [
@@ -610,6 +629,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Creates a Book resource.',
+        type: 'create',
         method: 'POST',
         expects: 'http://schema.org/Book',
         returns: 'http://schema.org/Book',
@@ -621,6 +641,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Retrieves Book resource.',
+        type: 'show',
         method: 'GET',
         returns: 'http://schema.org/Book',
         types: [
@@ -631,6 +652,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Replaces the Book resource.',
+        type: 'edit',
         method: 'PUT',
         expects: 'http://schema.org/Book',
         returns: 'http://schema.org/Book',
@@ -642,6 +664,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Deletes the Book resource.',
+        type: 'delete',
         method: 'DELETE',
         returns: 'http://www.w3.org/2002/07/owl#Nothing',
         types: [
@@ -728,6 +751,7 @@ const resources: Resource[] = [
     operations: [
       {
         name: 'Retrieves the collection of Parchment resources.',
+        type: 'list',
         method: 'GET',
         returns: 'http://www.w3.org/ns/hydra/core#Collection',
         types: [
@@ -738,6 +762,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Creates a Parchment resource.',
+        type: 'create',
         method: 'POST',
         expects: 'https://demo.api-platform.com/docs.jsonld#Parchment',
         returns: 'https://demo.api-platform.com/docs.jsonld#Parchment',
@@ -749,6 +774,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Retrieves Parchment resource.',
+        type: 'show',
         method: 'GET',
         returns: 'https://demo.api-platform.com/docs.jsonld#Parchment',
         types: [
@@ -759,6 +785,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Deletes the Parchment resource.',
+        type: 'delete',
         method: 'DELETE',
         returns: 'http://www.w3.org/2002/07/owl#Nothing',
         types: [
@@ -769,6 +796,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Replaces the Parchment resource.',
+        type: 'edit',
         method: 'PUT',
         expects: 'https://demo.api-platform.com/docs.jsonld#Parchment',
         returns: 'https://demo.api-platform.com/docs.jsonld#Parchment',
@@ -780,6 +808,7 @@ const resources: Resource[] = [
       },
       {
         name: 'Updates the Parchment resource.',
+        type: 'edit',
         method: 'PATCH',
         expects: 'https://demo.api-platform.com/docs.jsonld#Parchment',
         returns: 'https://demo.api-platform.com/docs.jsonld#Parchment',

--- a/src/__snapshots__/ResourceGuesser.test.tsx.snap
+++ b/src/__snapshots__/ResourceGuesser.test.tsx.snap
@@ -1,81 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ResourceGuesser /> renders with create 1`] = `
-<Resource
+<Introspecter
+  component={[Function]}
   create={[Function]}
-  edit={[Function]}
-  list={[Function]}
-  name="dummy"
-  show={[Function]}
+  resource="dummy"
 />
 `;
 
 exports[`<ResourceGuesser /> renders with edit 1`] = `
-<Resource
-  create={[Function]}
+<Introspecter
+  component={[Function]}
   edit={[Function]}
-  list={[Function]}
-  name="dummy"
-  show={[Function]}
+  resource="dummy"
 />
 `;
 
 exports[`<ResourceGuesser /> renders with list 1`] = `
-<Resource
-  create={[Function]}
-  edit={[Function]}
+<Introspecter
+  component={[Function]}
   list={[Function]}
-  name="dummy"
-  show={[Function]}
+  resource="dummy"
 />
 `;
 
 exports[`<ResourceGuesser /> renders with show 1`] = `
-<Resource
-  create={[Function]}
-  edit={[Function]}
-  list={[Function]}
-  name="dummy"
+<Introspecter
+  component={[Function]}
+  resource="dummy"
   show={[Function]}
 />
 `;
 
 exports[`<ResourceGuesser /> renders without create 1`] = `
-<Resource
-  create={[Function]}
-  edit={[Function]}
-  list={[Function]}
-  name="dummy"
-  show={[Function]}
+<Introspecter
+  component={[Function]}
+  resource="dummy"
 />
 `;
 
 exports[`<ResourceGuesser /> renders without edit 1`] = `
-<Resource
-  create={[Function]}
-  edit={[Function]}
-  list={[Function]}
-  name="dummy"
-  show={[Function]}
+<Introspecter
+  component={[Function]}
+  resource="dummy"
 />
 `;
 
 exports[`<ResourceGuesser /> renders without list 1`] = `
-<Resource
-  create={[Function]}
-  edit={[Function]}
-  list={[Function]}
-  name="dummy"
-  show={[Function]}
+<Introspecter
+  component={[Function]}
+  resource="dummy"
 />
 `;
 
 exports[`<ResourceGuesser /> renders without show 1`] = `
-<Resource
-  create={[Function]}
-  edit={[Function]}
-  list={[Function]}
-  name="dummy"
-  show={[Function]}
+<Introspecter
+  component={[Function]}
+  resource="dummy"
 />
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ import type {
   ReferenceArrayInputProps,
   ReferenceFieldProps,
   ReferenceInputProps,
+  ResourceProps,
   ShowProps,
   SimpleFormProps,
   TextFieldProps,
@@ -353,6 +354,14 @@ type BaseIntrospecterProps = Pick<
   'component' | 'resource'
 > &
   Partial<Pick<ResourcesIntrospecterProps, 'includeDeprecated'>>;
+
+export type IntrospectedResourceGuesserProps = Omit<ResourceProps, 'name'> &
+  IntrospectedGuesserProps;
+
+export type ResourceGuesserProps = Omit<
+  ResourceProps & Omit<BaseIntrospecterProps, 'resource'>,
+  'component'
+>;
 
 type CreateSimpleFormProps = Omit<
   CreateProps & Omit<SimpleFormProps, 'component'>,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fixes #441
| License       | MIT
| Doc PR        | N/A

The operations were not taken into account. For instance if a resource doesn't have a `POST` path, the `create` operation will be disabled: the create button will not be displayed in the list.

The admin does it by doing an introspection in the `ResourceGuesser` component (it was not the case before) and by registering again (the first registration is done with the `registerResource` static method) the resource with the correct operations.