### PR TITLE
fix: remove type module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lib",
     "src"
   ],
-  "type": "module",
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",


### PR DESCRIPTION
We don't want to use fully specified imports (yet).