### PR TITLE
fix: build only esm

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,7 +25,7 @@ module.exports = {
         'prettier',
       ],
       parserOptions: {
-        project: ['./tsconfig.json'],
+        project: ['./tsconfig.eslint.json'],
       },
       rules: {
         '@typescript-eslint/no-use-before-define': 'error',

--- a/package.json
+++ b/package.json
@@ -8,14 +8,9 @@
     "lib",
     "src"
   ],
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
-  },
-  "main": "./lib/cjs/index.js",
-  "module": "./lib/esm/index.js",
+  "type": "module",
+  "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "repository": "api-platform/admin",
   "homepage": "https://github.com/api-platform/admin",
   "bugs": "https://github.com/api-platform/admin/issues",
@@ -69,7 +64,7 @@
     "react-dom": "*"
   },
   "scripts": {
-    "build": "rimraf ./lib && tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
+    "build": "rimraf ./lib && tsc",
     "eslint-check": "eslint-config-prettier .eslintrc.cjs",
     "fix": "eslint --ignore-pattern 'lib/*' --ext .ts,.tsx,.js,.md --fix .",
     "lint": "eslint --ignore-pattern 'lib/*' --ext .ts,.tsx,.js,.md .",

--- a/src/AdminGuesser.test.tsx
+++ b/src/AdminGuesser.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer/shallow';
-import { AdminResourcesGuesser } from './AdminGuesser';
-import ResourceGuesser from './ResourceGuesser';
-import resources from './__fixtures__/resources';
-import { API_DATA } from './__fixtures__/parsedData';
+import { AdminResourcesGuesser } from './AdminGuesser.js';
+import ResourceGuesser from './ResourceGuesser.js';
+import resources from './__fixtures__/resources.js';
+import { API_DATA } from './__fixtures__/parsedData.js';
 import type {
   ApiPlatformAdminDataProvider,
   ApiPlatformAdminRecord,
-} from './types';
+} from './types.js';
 
 const dataProvider: ApiPlatformAdminDataProvider = {
   getList: () => Promise.resolve({ data: [], total: 0 }),

--- a/src/AdminGuesser.tsx
+++ b/src/AdminGuesser.tsx
@@ -15,15 +15,20 @@ import type { ComponentType, ErrorInfo } from 'react';
 import type { AdminProps, ErrorProps } from 'react-admin';
 import type { Resource } from '@api-platform/api-doc-parser';
 
-import IntrospectionContext from './IntrospectionContext';
-import ResourceGuesser from './ResourceGuesser';
-import SchemaAnalyzerContext from './SchemaAnalyzerContext';
-import { Error as DefaultError, Layout, LoginPage, lightTheme } from './layout';
+import IntrospectionContext from './IntrospectionContext.js';
+import ResourceGuesser from './ResourceGuesser.js';
+import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';
+import {
+  Error as DefaultError,
+  Layout,
+  LoginPage,
+  lightTheme,
+} from './layout/index.js';
 import getRoutesAndResourcesFromNodes, {
   isSingleChildFunction,
-} from './getRoutesAndResourcesFromNodes';
-import useDisplayOverrideCode from './useDisplayOverrideCode';
-import type { ApiPlatformAdminDataProvider, SchemaAnalyzer } from './types';
+} from './getRoutesAndResourcesFromNodes.js';
+import useDisplayOverrideCode from './useDisplayOverrideCode.js';
+import type { ApiPlatformAdminDataProvider, SchemaAnalyzer } from './types.js';
 
 export interface AdminGuesserProps extends AdminProps {
   dataProvider: ApiPlatformAdminDataProvider;

--- a/src/CreateGuesser.tsx
+++ b/src/CreateGuesser.tsx
@@ -12,13 +12,13 @@ import {
 import type { HttpError, RaRecord } from 'react-admin';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
-import InputGuesser from './InputGuesser';
-import Introspecter from './Introspecter';
-import useDisplayOverrideCode from './useDisplayOverrideCode';
+import InputGuesser from './InputGuesser.js';
+import Introspecter from './Introspecter.js';
+import useDisplayOverrideCode from './useDisplayOverrideCode.js';
 import type {
   CreateGuesserProps,
   IntrospectedCreateGuesserProps,
-} from './types';
+} from './types.js';
 
 const getOverrideCode = (schema: Resource, fields: Field[]) => {
   let code =

--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -13,11 +13,14 @@ import type { HttpError, RaRecord } from 'react-admin';
 import { useParams } from 'react-router-dom';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
-import InputGuesser from './InputGuesser';
-import Introspecter from './Introspecter';
-import useMercureSubscription from './useMercureSubscription';
-import useDisplayOverrideCode from './useDisplayOverrideCode';
-import type { EditGuesserProps, IntrospectedEditGuesserProps } from './types';
+import InputGuesser from './InputGuesser.js';
+import Introspecter from './Introspecter.js';
+import useMercureSubscription from './useMercureSubscription.js';
+import useDisplayOverrideCode from './useDisplayOverrideCode.js';
+import type {
+  EditGuesserProps,
+  IntrospectedEditGuesserProps,
+} from './types.js';
 
 const getOverrideCode = (schema: Resource, fields: Field[]) => {
   let code =

--- a/src/FieldGuesser.tsx
+++ b/src/FieldGuesser.tsx
@@ -28,13 +28,13 @@ import type {
 } from 'react-admin';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
-import Introspecter from './Introspecter';
+import Introspecter from './Introspecter.js';
 import type {
   FieldGuesserProps,
   FieldProps,
   IntrospectedFieldGuesserProps,
   SchemaAnalyzer,
-} from './types';
+} from './types.js';
 
 const isFieldSortable = (field: Field, schema: Resource) =>
   !!schema.parameters &&

--- a/src/FilterGuesser.tsx
+++ b/src/FilterGuesser.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { Filter, useResourceContext } from 'react-admin';
-import InputGuesser from './InputGuesser';
-import Introspecter from './Introspecter';
+import InputGuesser from './InputGuesser.js';
+import Introspecter from './Introspecter.js';
 import type {
   FilterGuesserProps,
   FilterParameter,
   IntrospectedFiterGuesserProps,
-} from './types';
+} from './types.js';
 
 export const IntrospectedFilterGuesser = ({
   fields,

--- a/src/InputGuesser.test.tsx
+++ b/src/InputGuesser.test.tsx
@@ -9,15 +9,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Resource } from '@api-platform/api-doc-parser';
 
-import InputGuesser from './InputGuesser';
-import SchemaAnalyzerContext from './SchemaAnalyzerContext';
-import schemaAnalyzer from './hydra/schemaAnalyzer';
+import InputGuesser from './InputGuesser.js';
+import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';
+import schemaAnalyzer from './hydra/schemaAnalyzer.js';
 import type {
   ApiPlatformAdminDataProvider,
   ApiPlatformAdminRecord,
-} from './types';
+} from './types.js';
 
-import { API_FIELDS_DATA } from './__fixtures__/parsedData';
+import { API_FIELDS_DATA } from './__fixtures__/parsedData.js';
 
 const hydraSchemaAnalyzer = schemaAnalyzer();
 const dataProvider: ApiPlatformAdminDataProvider = {

--- a/src/InputGuesser.tsx
+++ b/src/InputGuesser.tsx
@@ -26,8 +26,11 @@ import type {
   TextInputProps,
 } from 'react-admin';
 import isPlainObject from 'lodash.isplainobject';
-import Introspecter from './Introspecter';
-import type { InputGuesserProps, IntrospectedInputGuesserProps } from './types';
+import Introspecter from './Introspecter.js';
+import type {
+  InputGuesserProps,
+  IntrospectedInputGuesserProps,
+} from './types.js';
 
 const convertEmptyStringToNull = (value: string) =>
   value === '' ? null : value;

--- a/src/Introspecter.tsx
+++ b/src/Introspecter.tsx
@@ -1,13 +1,13 @@
 import React, { useContext, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useLogoutIfAccessDenied } from 'react-admin';
-import SchemaAnalyzerContext from './SchemaAnalyzerContext';
-import useIntrospect from './useIntrospect';
+import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';
+import useIntrospect from './useIntrospect.js';
 import type {
   IntrospecterProps,
   ResourcesIntrospecterProps,
   SchemaAnalyzer,
-} from './types';
+} from './types.js';
 
 const ResourcesIntrospecter = ({
   component: Component,

--- a/src/ListGuesser.tsx
+++ b/src/ListGuesser.tsx
@@ -12,16 +12,16 @@ import {
 import type { DatagridBodyProps } from 'react-admin';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
-import FieldGuesser from './FieldGuesser';
-import FilterGuesser from './FilterGuesser';
-import Introspecter from './Introspecter';
-import useMercureSubscription from './useMercureSubscription';
-import useDisplayOverrideCode from './useDisplayOverrideCode';
+import FieldGuesser from './FieldGuesser.js';
+import FilterGuesser from './FilterGuesser.js';
+import Introspecter from './Introspecter.js';
+import useMercureSubscription from './useMercureSubscription.js';
+import useDisplayOverrideCode from './useDisplayOverrideCode.js';
 import type {
   ApiPlatformAdminRecord,
   IntrospectedListGuesserProps,
   ListGuesserProps,
-} from './types';
+} from './types.js';
 
 const getOverrideCode = (schema: Resource, fields: Field[]) => {
   let code =

--- a/src/ResourceGuesser.test.tsx
+++ b/src/ResourceGuesser.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer/shallow';
-import ResourceGuesser from './ResourceGuesser';
+import ResourceGuesser from './ResourceGuesser.js';
 
 describe('<ResourceGuesser />', () => {
   const renderer = ReactTestRenderer.createRenderer();

--- a/src/ResourceGuesser.tsx
+++ b/src/ResourceGuesser.tsx
@@ -6,15 +6,15 @@ import {
   useResourceDefinitionContext,
 } from 'react-admin';
 import type { ResourceDefinition, ResourceProps } from 'react-admin';
-import ListGuesser from './ListGuesser';
-import CreateGuesser from './CreateGuesser';
-import EditGuesser from './EditGuesser';
-import ShowGuesser from './ShowGuesser';
-import Introspecter from './Introspecter';
+import ListGuesser from './ListGuesser.js';
+import CreateGuesser from './CreateGuesser.js';
+import EditGuesser from './EditGuesser.js';
+import ShowGuesser from './ShowGuesser.js';
+import Introspecter from './Introspecter.js';
 import type {
   IntrospectedResourceGuesserProps,
   ResourceGuesserProps,
-} from './types';
+} from './types.js';
 
 export const IntrospectedResourceGuesser = ({
   resource,

--- a/src/SchemaAnalyzerContext.ts
+++ b/src/SchemaAnalyzerContext.ts
@@ -1,7 +1,7 @@
 import {
   /* tree-shaking no-side-effects-when-called */ createContext,
 } from 'react';
-import type { SchemaAnalyzer } from './types';
+import type { SchemaAnalyzer } from './types.js';
 
 const SchemaAnalyzerContext = createContext<SchemaAnalyzer | null>(null);
 

--- a/src/ShowGuesser.test.tsx
+++ b/src/ShowGuesser.test.tsx
@@ -3,15 +3,15 @@ import { AdminContext, ResourceContextProvider, TextField } from 'react-admin';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Resource } from '@api-platform/api-doc-parser';
 
-import ShowGuesser from './ShowGuesser';
-import SchemaAnalyzerContext from './SchemaAnalyzerContext';
-import schemaAnalyzer from './hydra/schemaAnalyzer';
+import ShowGuesser from './ShowGuesser.js';
+import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';
+import schemaAnalyzer from './hydra/schemaAnalyzer.js';
 import type {
   ApiPlatformAdminDataProvider,
   ApiPlatformAdminRecord,
-} from './types';
+} from './types.js';
 
-import { API_FIELDS_DATA } from './__fixtures__/parsedData';
+import { API_FIELDS_DATA } from './__fixtures__/parsedData.js';
 
 const hydraSchemaAnalyzer = schemaAnalyzer();
 const dataProvider: ApiPlatformAdminDataProvider = {

--- a/src/ShowGuesser.tsx
+++ b/src/ShowGuesser.tsx
@@ -4,11 +4,14 @@ import { Show, SimpleShowLayout, useResourceContext } from 'react-admin';
 import { useParams } from 'react-router-dom';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
-import FieldGuesser from './FieldGuesser';
-import Introspecter from './Introspecter';
-import useMercureSubscription from './useMercureSubscription';
-import useDisplayOverrideCode from './useDisplayOverrideCode';
-import type { IntrospectedShowGuesserProps, ShowGuesserProps } from './types';
+import FieldGuesser from './FieldGuesser.js';
+import Introspecter from './Introspecter.js';
+import useMercureSubscription from './useMercureSubscription.js';
+import useDisplayOverrideCode from './useDisplayOverrideCode.js';
+import type {
+  IntrospectedShowGuesserProps,
+  ShowGuesserProps,
+} from './types.js';
 
 const getOverrideCode = (schema: Resource, fields: Field[]) => {
   let code =

--- a/src/dataProvider/adminDataProvider.ts
+++ b/src/dataProvider/adminDataProvider.ts
@@ -1,11 +1,11 @@
 import type { Api, Resource } from '@api-platform/api-doc-parser';
-import { mercureManager } from '../mercure';
+import { mercureManager } from '../mercure/index.js';
 import type {
   ApiDocumentationParserResponse,
   ApiPlatformAdminDataProviderFactoryParams,
   ApiPlatformAdminRecord,
   MercureOptions,
-} from '../types';
+} from '../types.js';
 
 export default (
   factoryParams: Required<ApiPlatformAdminDataProviderFactoryParams>,

--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -1,5 +1,5 @@
-import adminDataProvider from './adminDataProvider';
-import restDataProvider from './restDataProvider';
-import useUpdateCache from './useUpdateCache';
+import adminDataProvider from './adminDataProvider.js';
+import restDataProvider from './restDataProvider.js';
+import useUpdateCache from './useUpdateCache.js';
 
 export { adminDataProvider, restDataProvider, useUpdateCache };

--- a/src/dataProvider/restDataProvider.ts
+++ b/src/dataProvider/restDataProvider.ts
@@ -1,7 +1,7 @@
 import { stringify } from 'query-string';
 import { fetchUtils } from 'react-admin';
 import type { DataProvider } from 'react-admin';
-import { removeTrailingSlash } from '../removeTrailingSlash';
+import { removeTrailingSlash } from '../removeTrailingSlash.js';
 
 // Based on https://github.com/marmelab/react-admin/blob/master/packages/ra-data-simple-rest/src/index.ts
 

--- a/src/dataProvider/useUpdateCache.ts
+++ b/src/dataProvider/useUpdateCache.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import type { GetListResult, Identifier } from 'react-admin';
 import { useQueryClient } from 'react-query';
-import type { ApiPlatformAdminRecord } from '../types';
+import type { ApiPlatformAdminRecord } from '../types.js';
 
 const useUpdateCache = () => {
   const queryClient = useQueryClient();

--- a/src/hydra/HydraAdmin.tsx
+++ b/src/hydra/HydraAdmin.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import dataProviderFactory from './dataProvider';
-import /* tree-shaking no-side-effects-when-called */ schemaAnalyzer from './schemaAnalyzer';
-import AdminGuesser from '../AdminGuesser';
-import type { AdminGuesserProps } from '../AdminGuesser';
-import type { MercureOptions } from '../types';
+import dataProviderFactory from './dataProvider.js';
+import /* tree-shaking no-side-effects-when-called */ schemaAnalyzer from './schemaAnalyzer.js';
+import AdminGuesser from '../AdminGuesser.js';
+import type { AdminGuesserProps } from '../AdminGuesser.js';
+import type { MercureOptions } from '../types.js';
 
 type AdminGuesserPartialProps = Omit<
   AdminGuesserProps,

--- a/src/hydra/dataProvider.test.ts
+++ b/src/hydra/dataProvider.test.ts
@@ -3,9 +3,9 @@ import { Response } from 'node-fetch';
 import type { parseHydraDocumentation } from '@api-platform/api-doc-parser';
 import dataProviderFactory, {
   transformJsonLdDocumentToReactAdminDocument,
-} from './dataProvider';
-import { API_DATA } from '../__fixtures__/parsedData';
-import type fetchHydra from './fetchHydra';
+} from './dataProvider.js';
+import { API_DATA } from '../__fixtures__/parsedData.js';
+import type fetchHydra from './fetchHydra.js';
 
 const EMBEDDED_ITEM = {
   '@id': '/books/2',

--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -22,11 +22,11 @@ import type {
   UpdateParams,
 } from 'react-admin';
 
-import fetchHydra from './fetchHydra';
-import { resolveSchemaParameters } from '../schemaAnalyzer';
-import { adminDataProvider } from '../dataProvider';
-import { mercureManager } from '../mercure';
-import { removeTrailingSlash } from '../removeTrailingSlash';
+import fetchHydra from './fetchHydra.js';
+import { resolveSchemaParameters } from '../schemaAnalyzer.js';
+import { adminDataProvider } from '../dataProvider/index.js';
+import { mercureManager } from '../mercure/index.js';
+import { removeTrailingSlash } from '../removeTrailingSlash.js';
 import type {
   ApiPlatformAdminDataProvider,
   ApiPlatformAdminDataProviderParams,
@@ -38,7 +38,7 @@ import type {
   HydraHttpClientResponse,
   MercureOptions,
   SearchParams,
-} from '../types';
+} from '../types.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isPlainObject = (value: any): value is object =>

--- a/src/hydra/fetchHydra.ts
+++ b/src/hydra/fetchHydra.ts
@@ -6,7 +6,7 @@ import {
 import jsonld from 'jsonld';
 import type { NodeObject } from 'jsonld';
 import type { JsonLdObj } from 'jsonld/jsonld-spec';
-import type { HttpClientOptions, HydraHttpClientResponse } from '../types';
+import type { HttpClientOptions, HydraHttpClientResponse } from '../types.js';
 
 /**
  * Sends HTTP requests to a Hydra API.

--- a/src/hydra/index.ts
+++ b/src/hydra/index.ts
@@ -1,8 +1,8 @@
-import dataProvider from './dataProvider';
-import fetchHydra from './fetchHydra';
-import HydraAdmin from './HydraAdmin';
-import type { HydraAdminProps } from './HydraAdmin';
-import schemaAnalyzer from './schemaAnalyzer';
+import dataProvider from './dataProvider.js';
+import fetchHydra from './fetchHydra.js';
+import HydraAdmin from './HydraAdmin.js';
+import type { HydraAdminProps } from './HydraAdmin.js';
+import schemaAnalyzer from './schemaAnalyzer.js';
 
 export {
   dataProvider,

--- a/src/hydra/schemaAnalyzer.ts
+++ b/src/hydra/schemaAnalyzer.ts
@@ -4,8 +4,8 @@ import type { JsonLdObj } from 'jsonld/jsonld-spec';
 import {
   getFiltersParametersFromSchema,
   getOrderParametersFromSchema,
-} from '../schemaAnalyzer';
-import type { SchemaAnalyzer, SubmissionErrors } from '../types';
+} from '../schemaAnalyzer.js';
+import type { SchemaAnalyzer, SubmissionErrors } from '../types.js';
 
 const withHttpScheme = (value: string | null | undefined) =>
   value?.startsWith('https://') ? value.replace(/^https/, 'http') : value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
-import AdminGuesser from './AdminGuesser';
-import CreateGuesser from './CreateGuesser';
-import EditGuesser from './EditGuesser';
-import FieldGuesser from './FieldGuesser';
-import InputGuesser from './InputGuesser';
-import Introspecter from './Introspecter';
-import ListGuesser from './ListGuesser';
-import ResourceGuesser from './ResourceGuesser';
-import SchemaAnalyzerContext from './SchemaAnalyzerContext';
-import ShowGuesser from './ShowGuesser';
-import useIntrospect from './useIntrospect';
-import useIntrospection from './useIntrospection';
-import useMercureSubscription from './useMercureSubscription';
+import AdminGuesser from './AdminGuesser.js';
+import CreateGuesser from './CreateGuesser.js';
+import EditGuesser from './EditGuesser.js';
+import FieldGuesser from './FieldGuesser.js';
+import InputGuesser from './InputGuesser.js';
+import Introspecter from './Introspecter.js';
+import ListGuesser from './ListGuesser.js';
+import ResourceGuesser from './ResourceGuesser.js';
+import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';
+import ShowGuesser from './ShowGuesser.js';
+import useIntrospect from './useIntrospect.js';
+import useIntrospection from './useIntrospection.js';
+import useMercureSubscription from './useMercureSubscription.js';
 
 export {
   AdminGuesser,
@@ -32,12 +32,12 @@ export {
   dataProvider as hydraDataProvider,
   schemaAnalyzer as hydraSchemaAnalyzer,
   fetchHydra,
-} from './hydra';
-export type { HydraAdminProps } from './hydra';
+} from './hydra/index.js';
+export type { HydraAdminProps } from './hydra/index.js';
 export {
   OpenApiAdmin,
   dataProvider as openApiDataProvider,
   schemaAnalyzer as openApiSchemaAnalyzer,
-} from './openapi';
-export type { OpenApiAdminProps } from './openapi';
-export * from './types';
+} from './openapi/index.js';
+export type { OpenApiAdminProps } from './openapi/index.js';
+export * from './types.js';

--- a/src/layout/AppBar.tsx
+++ b/src/layout/AppBar.tsx
@@ -8,8 +8,8 @@ import {
 import type { AppBarProps } from 'react-admin';
 import { Box, Typography } from '@mui/material';
 
-import Logo from './Logo';
-import { darkTheme, lightTheme } from './themes';
+import Logo from './Logo.js';
+import { darkTheme, lightTheme } from './themes.js';
 
 const CustomAppBar = ({ classes, userMenu, ...props }: AppBarProps) => {
   const authProvider = useAuthProvider();

--- a/src/layout/Error.tsx
+++ b/src/layout/Error.tsx
@@ -15,7 +15,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import HistoryIcon from '@mui/icons-material/History';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import type { FallbackProps } from 'react-error-boundary';
-import LogoError from './LogoError';
+import LogoError from './LogoError.js';
 
 const PREFIX = 'RaError';
 

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Layout } from 'react-admin';
 import type { LayoutProps } from 'react-admin';
-import AppBar from './AppBar';
-import DefaultError from './Error';
+import AppBar from './AppBar.js';
+import DefaultError from './Error.js';
 
 const CustomLayout = (props: LayoutProps) => (
   <Layout appBar={AppBar} error={DefaultError} {...props} />

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -1,6 +1,6 @@
-import Error from './Error';
-import Layout from './Layout';
-import LoginPage from './LoginPage';
+import Error from './Error.js';
+import Layout from './Layout.js';
+import LoginPage from './LoginPage.js';
 
 export { Error, Layout, LoginPage };
-export * from './themes';
+export * from './themes.js';

--- a/src/mercure/createSubscription.ts
+++ b/src/mercure/createSubscription.ts
@@ -3,7 +3,7 @@ import type {
   DataTransformer,
   MercureOptions,
   MercureSubscription,
-} from '../types';
+} from '../types.js';
 
 const createSubscription = (
   mercure: MercureOptions,

--- a/src/mercure/index.ts
+++ b/src/mercure/index.ts
@@ -1,4 +1,4 @@
-import createSubscription from './createSubscription';
-import manager from './manager';
+import createSubscription from './createSubscription.js';
+import manager from './manager.js';
 
 export { createSubscription, manager as mercureManager };

--- a/src/mercure/manager.ts
+++ b/src/mercure/manager.ts
@@ -1,10 +1,10 @@
-import createSubscription from './createSubscription';
+import createSubscription from './createSubscription.js';
 import type {
   ApiPlatformAdminRecord,
   DataTransformer,
   MercureOptions,
   MercureSubscription,
-} from '../types';
+} from '../types.js';
 
 // store mercure subscriptions
 const subscriptions: Record<string, MercureSubscription> = {};

--- a/src/openapi/OpenApiAdmin.tsx
+++ b/src/openapi/OpenApiAdmin.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import dataProviderFactory from './dataProvider';
-import { restDataProvider } from '../dataProvider';
-import /* tree-shaking no-side-effects-when-called */ schemaAnalyzer from './schemaAnalyzer';
-import AdminGuesser from '../AdminGuesser';
-import type { AdminGuesserProps } from '../AdminGuesser';
-import type { MercureOptions } from '../types';
+import dataProviderFactory from './dataProvider.js';
+import { restDataProvider } from '../dataProvider/index.js';
+import /* tree-shaking no-side-effects-when-called */ schemaAnalyzer from './schemaAnalyzer.js';
+import AdminGuesser from '../AdminGuesser.js';
+import type { AdminGuesserProps } from '../AdminGuesser.js';
+import type { MercureOptions } from '../types.js';
 
 type AdminGuesserPartialProps = Omit<
   AdminGuesserProps,

--- a/src/openapi/dataProvider.ts
+++ b/src/openapi/dataProvider.ts
@@ -1,12 +1,12 @@
 import { parseOpenApi3Documentation } from '@api-platform/api-doc-parser';
 import { fetchUtils } from 'react-admin';
-import { adminDataProvider } from '../dataProvider';
+import { adminDataProvider } from '../dataProvider/index.js';
 import type {
   ApiPlatformAdminDataProvider,
   HttpClientOptions,
   MercureOptions,
   OpenApiDataProviderFactoryParams,
-} from '../types';
+} from '../types.js';
 
 const fetchJson = (url: URL, options: HttpClientOptions = {}) => {
   let { headers } = options;

--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -1,6 +1,6 @@
-import dataProvider from './dataProvider';
-import OpenApiAdmin from './OpenApiAdmin';
-import type { OpenApiAdminProps } from './OpenApiAdmin';
-import schemaAnalyzer from './schemaAnalyzer';
+import dataProvider from './dataProvider.js';
+import OpenApiAdmin from './OpenApiAdmin.js';
+import type { OpenApiAdminProps } from './OpenApiAdmin.js';
+import schemaAnalyzer from './schemaAnalyzer.js';
 
 export { dataProvider, OpenApiAdmin, OpenApiAdminProps, schemaAnalyzer };

--- a/src/openapi/schemaAnalyzer.ts
+++ b/src/openapi/schemaAnalyzer.ts
@@ -2,8 +2,8 @@ import type { Field, Resource } from '@api-platform/api-doc-parser';
 import {
   getFiltersParametersFromSchema,
   getOrderParametersFromSchema,
-} from '../schemaAnalyzer';
-import type { SchemaAnalyzer } from '../types';
+} from '../schemaAnalyzer.js';
+import type { SchemaAnalyzer } from '../types.js';
 
 /**
  * @param schema The schema of a resource

--- a/src/schemaAnalyzer.ts
+++ b/src/schemaAnalyzer.ts
@@ -1,5 +1,5 @@
 import type { Resource } from '@api-platform/api-doc-parser';
-import type { FilterParameter } from './types';
+import type { FilterParameter } from './types.js';
 
 /**
  * @param schema The schema of a resource

--- a/src/useIntrospect.ts
+++ b/src/useIntrospect.ts
@@ -1,7 +1,10 @@
 import { useQuery } from 'react-query';
 import { useDataProvider } from 'react-admin';
 import type { UseQueryOptions } from 'react-query';
-import type { ApiPlatformAdminDataProvider, IntrospectPayload } from './types';
+import type {
+  ApiPlatformAdminDataProvider,
+  IntrospectPayload,
+} from './types.js';
 
 const useIntrospect = (options?: UseQueryOptions<IntrospectPayload, Error>) => {
   const dataProvider = useDataProvider<ApiPlatformAdminDataProvider>();

--- a/src/useIntrospection.ts
+++ b/src/useIntrospection.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import IntrospectionContext from './IntrospectionContext';
+import IntrospectionContext from './IntrospectionContext.js';
 
 const useIntrospection = () => useContext(IntrospectionContext).introspect;
 

--- a/src/useMercureSubscription.ts
+++ b/src/useMercureSubscription.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useDataProvider } from 'react-admin';
 import type { Identifier } from 'react-admin';
-import { useUpdateCache } from './dataProvider';
-import type { ApiPlatformAdminDataProvider } from './types';
+import { useUpdateCache } from './dataProvider/index.js';
+import type { ApiPlatformAdminDataProvider } from './types.js';
 
 export default function useMercureSubscription(
   resource: string | undefined,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["./src/**/*.test.ts", "./src/**/*.test.tsx"]
-}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "./lib/cjs",
-  }
-}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": []
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "node",
-    "outDir": "./lib/esm",
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "target": "ES6",
     "lib": ["ESNext", "dom", "dom.iterable"],
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "./lib/cjs",
+    "outDir": "./lib",
     "declaration": true,
     "declarationMap": true,
     "rootDir": "./src",
@@ -21,5 +21,6 @@
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true
   },
+  "exclude": ["./src/**/*.test.ts", "./src/**/*.test.tsx"],
   "include": ["./src"]
 }


### PR DESCRIPTION
More and more packages are ESM only: it doesn't make sense to continue to build CJS.