### PR TITLE
fix reference input validation

### DIFF
--- a/src/InputGuesser.tsx
+++ b/src/InputGuesser.tsx
@@ -23,6 +23,8 @@ import type {
   NumberInputProps,
   ReferenceArrayInputProps,
   ReferenceInputProps,
+  SelectArrayInputProps,
+  SelectInputProps,
   TextInputProps,
 } from 'react-admin';
 import isPlainObject from 'lodash.isplainobject';
@@ -61,31 +63,45 @@ export const IntrospectedInputGuesser = ({
 
   if (field.reference !== null && typeof field.reference === 'object') {
     if (field.maxCardinality === 1) {
+      const { filter, page, perPage, sort, enableGetChoices } =
+        props as ReferenceInputProps;
+
       return (
         <ReferenceInput
           key={field.name}
-          {...(props as ReferenceInputProps)}
           reference={field.reference.name}
           source={field.name}
-          allowEmpty>
+          filter={filter}
+          page={page}
+          perPage={perPage}
+          sort={sort}
+          enableGetChoices={enableGetChoices}>
           <SelectInput
             optionText={schemaAnalyzer.getFieldNameFromSchema(field.reference)}
             validate={guessedValidate}
+            {...(props as SelectInputProps)}
           />
         </ReferenceInput>
       );
     }
 
+    const { filter, page, perPage, sort, enableGetChoices } =
+      props as ReferenceArrayInputProps;
+
     return (
       <ReferenceArrayInput
         key={field.name}
-        {...(props as ReferenceArrayInputProps)}
         reference={field.reference.name}
         source={field.name}
-        allowEmpty>
+        filter={filter}
+        page={page}
+        perPage={perPage}
+        sort={sort}
+        enableGetChoices={enableGetChoices}>
         <SelectArrayInput
           optionText={schemaAnalyzer.getFieldNameFromSchema(field.reference)}
           validate={guessedValidate}
+          {...(props as SelectArrayInputProps)}
         />
       </ReferenceArrayInput>
     );

--- a/src/InputGuesser.tsx
+++ b/src/InputGuesser.tsx
@@ -64,13 +64,13 @@ export const IntrospectedInputGuesser = ({
       return (
         <ReferenceInput
           key={field.name}
-          validate={guessedValidate}
           {...(props as ReferenceInputProps)}
           reference={field.reference.name}
           source={field.name}
           allowEmpty>
           <SelectInput
             optionText={schemaAnalyzer.getFieldNameFromSchema(field.reference)}
+            validate={guessedValidate}
           />
         </ReferenceInput>
       );
@@ -79,13 +79,13 @@ export const IntrospectedInputGuesser = ({
     return (
       <ReferenceArrayInput
         key={field.name}
-        validate={guessedValidate}
         {...(props as ReferenceArrayInputProps)}
         reference={field.reference.name}
         source={field.name}
         allowEmpty>
         <SelectArrayInput
           optionText={schemaAnalyzer.getFieldNameFromSchema(field.reference)}
+          validate={guessedValidate}
         />
       </ReferenceArrayInput>
     );


### PR DESCRIPTION
Required referenced fields are not marked as required by InputGuesser:

For example field form parsed from hydra:
```js
{ 
  name: "sourceLanguage", 
  (...)
  embedded: null,
  required: true,
  maxCardinality: 1,
  deprecated: false
}
```
Looks like this:
![obraz](https://user-images.githubusercontent.com/1256986/190605615-dc152ae6-8eb6-4d7b-8a9b-a557a13a62c9.png)
SwaggerUI recognizes it correctly:
![obraz](https://user-images.githubusercontent.com/1256986/190612382-cdd73611-4ba0-42e2-9141-ea1158dba4c0.png)

It seems that validation prop should be passed directly to Input field component, not to ReferenceInput wrapper. With that change all works fine.