### PR TITLE
multiple file upload

### DIFF
--- a/src/hydra/dataProvider.test.ts
+++ b/src/hydra/dataProvider.test.ts
@@ -216,11 +216,15 @@ describe('Transform a React Admin request to an Hydra request', () => {
     await dataProvider.introspect();
 
     const file = new File(['foo'], 'foo.txt');
+    const icons = [...Array(3).keys()].map((i) => ({
+      rawFile: new File([`icon_${i}`], `icon_${i}.png`),
+    }));
     await dataProvider.create('resource', {
       data: {
         image: {
           rawFile: file,
         },
+        icons,
         bar: 'baz',
         qux: null,
         array: ['foo', 'dummy'],
@@ -238,6 +242,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
     expect(options.body).toBeInstanceOf(FormData);
     expect(Array.from((options.body as FormData).entries())).toEqual([
       ['image', file],
+      ...icons.map((icon) => ['icons[]', icon.rawFile]),
       ['bar', 'baz'],
       ['qux', 'null'],
       ['array', '["foo","dummy"]'],

--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -255,11 +255,16 @@ function dataProvider(
       data as Record<string, unknown>,
     ).then((hydraData) => {
       const values = Object.values(hydraData);
-      const containFile = (element: unknown) =>
-        isPlainObject(element) &&
-        Object.values(element as Record<string, unknown>).some(
-          (value) => value instanceof File,
-        );
+      const containFile = (element: unknown): boolean =>
+        Array.isArray(element)
+          ? element
+              .map((value) => containFile(value))
+              .every((contain) => contain)
+          : isPlainObject(element) &&
+            Object.values(element as Record<string, unknown>).some(
+              (value) => value instanceof File,
+            );
+
       type ToJSONObject = { toJSON(): string };
       const hasToJSON = (
         element: string | ToJSONObject,
@@ -281,10 +286,17 @@ function dataProvider(
       ).forEach(([key, value]) => {
         // React-Admin FileInput format is an object containing a file.
         if (containFile(value)) {
-          body.append(
-            key,
-            Object.values(value).find((val) => val instanceof File),
-          );
+          const findFile = (element: string | ToJSONObject): Blob =>
+            Object.values(element).find((val) => val instanceof File);
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          Array.isArray(value)
+            ? value
+                .map((val) => findFile(val))
+                .forEach((file) => {
+                  body.append(key.endsWith('[]') ? key : `${key}[]`, file);
+                })
+            : body.append(key, findFile(value));
+
           return;
         }
         if (hasToJSON(value)) {

--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -257,9 +257,7 @@ function dataProvider(
       const values = Object.values(hydraData);
       const containFile = (element: unknown): boolean =>
         Array.isArray(element)
-          ? element
-              .map((value) => containFile(value))
-              .every((contain) => contain)
+          ? element.every((value) => containFile(value))
           : isPlainObject(element) &&
             Object.values(element as Record<string, unknown>).some(
               (value) => value instanceof File,


### PR DESCRIPTION
Support of multiple files upload by dataProvider.

Example of usage:

```js
 <CreateGuesser {...props}>
    <FileInput source={"docs"} multiple={true} >
        <FileField source={"src"} title={"title"} download />
     </FileInput>
    (...)
 </CreateGuesser>
```
Some screenshot:
![obraz](https://user-images.githubusercontent.com/1256986/191980652-4f4ea1c1-c524-4c89-a4b0-841dbbc01e3f.png)




