### PR TITLE
feat: allow to use tabbed components in guessers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.0
+
+* Handle multiple file upload
+* Allow to use tabbed components in guessers
+
 ## 3.3.8
 
 * Fix reference input validation

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "fix": "eslint --ignore-pattern 'lib/*' --ext .ts,.tsx,.js,.md --fix .",
     "lint": "eslint --ignore-pattern 'lib/*' --ext .ts,.tsx,.js,.md .",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=1 src",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch src",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=1 --watch src",
     "watch": "tsc --watch"
   }
 }

--- a/src/CreateGuesser.test.tsx
+++ b/src/CreateGuesser.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { AdminContext, FormTab, TextInput } from 'react-admin';
+import { Resource } from '@api-platform/api-doc-parser';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CreateGuesser from './CreateGuesser.js';
+import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';
+import schemaAnalyzer from './hydra/schemaAnalyzer.js';
+import type {
+  ApiPlatformAdminDataProvider,
+  ApiPlatformAdminRecord,
+} from './types.js';
+
+import { API_FIELDS_DATA } from './__fixtures__/parsedData.js';
+
+const hydraSchemaAnalyzer = schemaAnalyzer();
+const dataProvider: ApiPlatformAdminDataProvider = {
+  getList: () => Promise.resolve({ data: [], total: 0 }),
+  getMany: () => Promise.resolve({ data: [] }),
+  getManyReference: () => Promise.resolve({ data: [], total: 0 }),
+  update: <RecordType extends ApiPlatformAdminRecord>() =>
+    Promise.resolve({ data: { id: 'id' } } as { data: RecordType }),
+  updateMany: () => Promise.resolve({ data: [] }),
+  create: <RecordType extends ApiPlatformAdminRecord>() =>
+    Promise.resolve({ data: { id: 'id' } } as { data: RecordType }),
+  delete: <RecordType extends ApiPlatformAdminRecord>() =>
+    Promise.resolve({ data: { id: 'id' } } as { data: RecordType }),
+  deleteMany: () => Promise.resolve({ data: [] }),
+  getOne: <RecordType extends ApiPlatformAdminRecord>() =>
+    Promise.resolve({ data: { id: 'id' } } as { data: RecordType }),
+  introspect: () =>
+    Promise.resolve({
+      data: {
+        entrypoint: 'entrypoint',
+        resources: [
+          new Resource('users', '/users', {
+            fields: API_FIELDS_DATA,
+            readableFields: API_FIELDS_DATA,
+            writableFields: API_FIELDS_DATA,
+            parameters: [],
+          }),
+        ],
+      },
+    }),
+  subscribe: () => Promise.resolve({ data: null }),
+  unsubscribe: () => Promise.resolve({ data: null }),
+};
+
+describe('<CreateGuesser />', () => {
+  test('renders with custom fields', async () => {
+    render(
+      <AdminContext dataProvider={dataProvider}>
+        <SchemaAnalyzerContext.Provider value={hydraSchemaAnalyzer}>
+          <CreateGuesser resource="users">
+            <TextInput source="id" label="label of id" />
+            <TextInput source="title" label="label of title" />
+            <TextInput source="body" label="label of body" />
+          </CreateGuesser>
+        </SchemaAnalyzerContext.Provider>
+      </AdminContext>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole('tab')).toHaveLength(0);
+      expect(screen.queryByText('label of id')).toBeVisible();
+      expect(screen.queryByText('label of title')).toBeVisible();
+      expect(screen.queryByText('label of body')).toBeVisible();
+    });
+  });
+
+  test.each([0, 1])('renders with tabs', async (tabId) => {
+    const user = userEvent.setup();
+
+    render(
+      <AdminContext dataProvider={dataProvider}>
+        <SchemaAnalyzerContext.Provider value={hydraSchemaAnalyzer}>
+          <CreateGuesser resource="users">
+            <FormTab label="FormTab 1">
+              <TextInput source="id" label="label of id" />
+              <TextInput source="title" label="label of title" />
+            </FormTab>
+            <FormTab label="FormTab 2">
+              <TextInput source="body" label="label of body" />
+            </FormTab>
+          </CreateGuesser>
+        </SchemaAnalyzerContext.Provider>
+      </AdminContext>,
+    );
+    await waitFor(async () => {
+      expect(screen.queryAllByRole('tab')).toHaveLength(2);
+      const tab = screen.getAllByRole('tab')[tabId];
+      if (tab) {
+        await user.click(tab);
+      }
+      if (tabId === 0) {
+        // First tab, available.
+        expect(screen.queryByText('label of id')).toBeVisible();
+        expect(screen.queryByText('label of title')).toBeVisible();
+        // Second tab, unavailable.
+        expect(screen.queryByText('label of body')).not.toBeVisible();
+      } else {
+        // First tab, unavailable.
+        expect(screen.queryByText('label of id')).not.toBeVisible();
+        expect(screen.queryByText('label of title')).not.toBeVisible();
+        // Second tab, available.
+        expect(screen.queryByText('label of body')).toBeVisible();
+      }
+    });
+  });
+});

--- a/src/InputGuesser.test.tsx
+++ b/src/InputGuesser.test.tsx
@@ -5,9 +5,9 @@ import {
   ResourceContextProvider,
   SimpleForm,
 } from 'react-admin';
+import { Resource } from '@api-platform/api-doc-parser';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Resource } from '@api-platform/api-doc-parser';
 
 import InputGuesser from './InputGuesser.js';
 import SchemaAnalyzerContext from './SchemaAnalyzerContext.js';

--- a/src/ShowGuesser.tsx
+++ b/src/ShowGuesser.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Show, SimpleShowLayout, useResourceContext } from 'react-admin';
+import {
+  Show,
+  SimpleShowLayout,
+  Tab,
+  TabbedShowLayout,
+  useResourceContext,
+} from 'react-admin';
 import { useParams } from 'react-router-dom';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
@@ -55,9 +61,17 @@ export const IntrospectedShowGuesser = ({
     displayOverrideCode(getOverrideCode(schema, readableFields));
   }
 
+  const hasTab =
+    Array.isArray(fieldChildren) &&
+    fieldChildren.some(
+      (child) =>
+        typeof child === 'object' && 'type' in child && child.type === Tab,
+    );
+  const ShowLayout = hasTab ? TabbedShowLayout : SimpleShowLayout;
+
   return (
     <Show {...props}>
-      <SimpleShowLayout>{fieldChildren}</SimpleShowLayout>
+      <ShowLayout>{fieldChildren}</ShowLayout>
     </Show>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ import type {
   ResourceProps,
   ShowProps,
   SimpleFormProps,
+  TabbedFormProps,
   TextFieldProps,
   TextInputProps,
   UPDATE,
@@ -365,38 +366,45 @@ export type ResourceGuesserProps = Omit<
   'component'
 >;
 
-type CreateSimpleFormProps = Omit<
-  CreateProps & Omit<SimpleFormProps, 'component'>,
+type CreateFormProps = Omit<
+  CreateProps & SimpleFormProps & TabbedFormProps,
   'children'
 > &
-  Partial<PickRename<SimpleFormProps, 'component', 'simpleFormComponent'>> & {
+  Partial<
+    PickRename<SimpleFormProps & TabbedFormProps, 'component', 'formComponent'>
+  > & {
     children?: ReactNode;
   };
 
-export type IntrospectedCreateGuesserProps = CreateSimpleFormProps &
+export type IntrospectedCreateGuesserProps = CreateFormProps &
   IntrospectedGuesserProps & {
     sanitizeEmptyValues?: boolean;
   };
 
 export type CreateGuesserProps = Omit<
-  CreateSimpleFormProps & Omit<BaseIntrospecterProps, 'resource'>,
+  CreateFormProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
 > & {
   sanitizeEmptyValues?: boolean;
 };
 
-type EditSimpleFormProps = Omit<EditProps & SimpleFormProps, 'children'> &
-  Partial<PickRename<SimpleFormProps, 'component', 'simpleFormComponent'>> & {
+type EditFormProps = Omit<
+  EditProps & SimpleFormProps & TabbedFormProps,
+  'children'
+> &
+  Partial<
+    PickRename<SimpleFormProps & TabbedFormProps, 'component', 'formComponent'>
+  > & {
     children?: ReactNode;
   };
 
-export type IntrospectedEditGuesserProps = EditSimpleFormProps &
+export type IntrospectedEditGuesserProps = EditFormProps &
   IntrospectedGuesserProps & {
     sanitizeEmptyValues?: boolean;
   };
 
 export type EditGuesserProps = Omit<
-  EditSimpleFormProps & Omit<BaseIntrospecterProps, 'resource'>,
+  EditFormProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
 > & {
   sanitizeEmptyValues?: boolean;
@@ -418,15 +426,18 @@ export type ListGuesserProps = Omit<
   'component'
 >;
 
-type ShowSimpleFormProps = Omit<ShowProps & SimpleFormProps, 'children'> & {
+type ShowFormProps = Omit<
+  ShowProps & SimpleFormProps & TabbedFormProps,
+  'children'
+> & {
   children?: ReactNode;
 };
 
-export type IntrospectedShowGuesserProps = ShowSimpleFormProps &
+export type IntrospectedShowGuesserProps = ShowFormProps &
   IntrospectedGuesserProps;
 
 export type ShowGuesserProps = Omit<
-  ShowSimpleFormProps & Omit<BaseIntrospecterProps, 'resource'>,
+  ShowFormProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
 >;
 


### PR DESCRIPTION
Extension that allows to use TabbedForm and TabbedShowLayout in place of SimpleForm and SimpleShowLayout.  Based on presence of tabbed element (FormTab / Tab)  appropriate type of form or show layout is choosen by guesser. 

https://marmelab.com/react-admin/doc/4.0/TabbedForm.html
https://marmelab.com/react-admin/doc/4.0/TabbedShowLayout.html

For example:
```
 <CreateGuesser {...props} >
      <FormTab label={"Tab 1"}>
        <InputGuesser source={"comments"} multiline  />
         (...)
      </FormTab>
     <FormTab label={"Tab 2"}>
         <InputGuesser source={"name"}
          (...)
      </FormTab>
</CreateGuesser>
```

Test case provided  for ShowGuesser for that moment.