### PR TITLE
feat: use native react-admin sanitizeEmptyValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Handle multiple file upload
 * Allow to use tabbed components in guessers
+* Use native react-admin `sanitizeEmptyValues`
 
 ## 3.3.8
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jsonld": "^8.1.0",
     "lodash.isplainobject": "^4.0.6",
     "prop-types": "^15.6.2",
-    "react-admin": "^4.0.3",
+    "react-admin": "^4.4.0",
     "react-error-boundary": "^3.1.0"
   },
   "devDependencies": {

--- a/src/CreateGuesser.tsx
+++ b/src/CreateGuesser.tsx
@@ -57,7 +57,7 @@ export const IntrospectedCreateGuesser = ({
   validate,
   toolbar,
   warnWhenUnsavedChanges,
-  sanitizeEmptyValues,
+  sanitizeEmptyValues = true,
   formComponent,
   children,
   ...props
@@ -71,11 +71,7 @@ export const IntrospectedCreateGuesser = ({
   let inputChildren = React.Children.toArray(children);
   if (inputChildren.length === 0) {
     inputChildren = writableFields.map((field) => (
-      <InputGuesser
-        key={field.name}
-        source={field.name}
-        sanitizeEmptyValue={sanitizeEmptyValues}
-      />
+      <InputGuesser key={field.name} source={field.name} />
     ));
     displayOverrideCode(getOverrideCode(schema, writableFields));
   }
@@ -174,6 +170,7 @@ export const IntrospectedCreateGuesser = ({
         validate={validate}
         toolbar={toolbar}
         warnWhenUnsavedChanges={warnWhenUnsavedChanges}
+        sanitizeEmptyValues={sanitizeEmptyValues}
         component={formComponent}>
         {inputChildren}
       </FormType>

--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -61,7 +61,7 @@ export const IntrospectedEditGuesser = ({
   toolbar,
   warnWhenUnsavedChanges,
   formComponent,
-  sanitizeEmptyValues,
+  sanitizeEmptyValues = true,
   children,
   ...props
 }: IntrospectedEditGuesserProps) => {
@@ -78,11 +78,7 @@ export const IntrospectedEditGuesser = ({
   let inputChildren = React.Children.toArray(children);
   if (inputChildren.length === 0) {
     inputChildren = writableFields.map((field) => (
-      <InputGuesser
-        key={field.name}
-        source={field.name}
-        sanitizeEmptyValue={sanitizeEmptyValues}
-      />
+      <InputGuesser key={field.name} source={field.name} />
     ));
     displayOverrideCode(getOverrideCode(schema, writableFields));
   }
@@ -195,6 +191,7 @@ export const IntrospectedEditGuesser = ({
         redirect={redirectTo}
         toolbar={toolbar}
         warnWhenUnsavedChanges={warnWhenUnsavedChanges}
+        sanitizeEmptyValues={sanitizeEmptyValues}
         component={formComponent}>
         {inputChildren}
       </FormType>

--- a/src/__fixtures__/parsedData.ts
+++ b/src/__fixtures__/parsedData.ts
@@ -13,6 +13,10 @@ export const API_DATA = new Api('entrypoint', {
   ],
 });
 
+const EmbeddedResource = new Resource('embedded', '/embeddeds', {
+  fields: [new Field('address')],
+});
+
 export const API_FIELDS_DATA = [
   new Field('id', {
     id: 'http://schema.org/id',
@@ -55,6 +59,26 @@ export const API_FIELDS_DATA = [
     range: 'http://www.w3.org/2001/XMLSchema#string',
     reference: null,
     embedded: null,
+    required: false,
+  }),
+  new Field('nullText', {
+    id: 'http://schema.org/nullText',
+    range: 'http://www.w3.org/2001/XMLSchema#string',
+    reference: null,
+    embedded: null,
+    required: false,
+  }),
+  new Field('embedded', {
+    id: 'http://schema.org/embedded',
+    reference: null,
+    embedded: EmbeddedResource,
+    maxCardinality: 1,
+    required: false,
+  }),
+  new Field('embeddeds', {
+    id: 'http://schema.org/embedded',
+    reference: null,
+    embedded: EmbeddedResource,
     required: false,
   }),
 ];

--- a/src/__snapshots__/AdminGuesser.test.tsx.snap
+++ b/src/__snapshots__/AdminGuesser.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`<AdminGuesser /> renders with custom resources 1`] = `
     {
       "changeLocale": [Function],
       "getLocale": [Function],
+      "getLocales": [Function],
       "translate": [Function],
     }
   }
@@ -37,6 +38,7 @@ exports[`<AdminGuesser /> renders with custom resources 1`] = `
     {
       "getItem": [Function],
       "removeItem": [Function],
+      "removeItems": [Function],
       "reset": [Function],
       "setItem": [Function],
       "setup": [Function],
@@ -73,6 +75,7 @@ exports[`<AdminGuesser /> renders without custom resources 1`] = `
     {
       "changeLocale": [Function],
       "getLocale": [Function],
+      "getLocales": [Function],
       "translate": [Function],
     }
   }
@@ -81,6 +84,7 @@ exports[`<AdminGuesser /> renders without custom resources 1`] = `
     {
       "getItem": [Function],
       "removeItem": [Function],
+      "removeItems": [Function],
       "reset": [Function],
       "setItem": [Function],
       "setup": [Function],
@@ -117,6 +121,7 @@ exports[`<AdminGuesser /> renders without data 1`] = `
     {
       "changeLocale": [Function],
       "getLocale": [Function],
+      "getLocales": [Function],
       "translate": [Function],
     }
   }
@@ -125,6 +130,7 @@ exports[`<AdminGuesser /> renders without data 1`] = `
     {
       "getItem": [Function],
       "removeItem": [Function],
+      "removeItems": [Function],
       "reset": [Function],
       "setItem": [Function],
       "setup": [Function],

--- a/src/types.ts
+++ b/src/types.ts
@@ -377,16 +377,12 @@ type CreateFormProps = Omit<
   };
 
 export type IntrospectedCreateGuesserProps = CreateFormProps &
-  IntrospectedGuesserProps & {
-    sanitizeEmptyValues?: boolean;
-  };
+  IntrospectedGuesserProps;
 
 export type CreateGuesserProps = Omit<
   CreateFormProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
-> & {
-  sanitizeEmptyValues?: boolean;
-};
+>;
 
 type EditFormProps = Omit<
   EditProps & SimpleFormProps & TabbedFormProps,
@@ -399,16 +395,12 @@ type EditFormProps = Omit<
   };
 
 export type IntrospectedEditGuesserProps = EditFormProps &
-  IntrospectedGuesserProps & {
-    sanitizeEmptyValues?: boolean;
-  };
+  IntrospectedGuesserProps;
 
 export type EditGuesserProps = Omit<
   EditFormProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
-> & {
-  sanitizeEmptyValues?: boolean;
-};
+>;
 
 type ListDatagridProps = Omit<
   ListProps & Omit<DatagridProps, 'sx'>,
@@ -482,16 +474,12 @@ type InputProps =
   | ReferenceInputProps;
 
 export type IntrospectedInputGuesserProps = Partial<InputProps> &
-  IntrospectedGuesserProps & {
-    sanitizeEmptyValue?: boolean;
-  };
+  IntrospectedGuesserProps;
 
 export type InputGuesserProps = Omit<
   InputProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
-> & {
-  sanitizeEmptyValue?: boolean;
-};
+>;
 
 export type IntrospecterProps = (
   | CreateGuesserProps


### PR DESCRIPTION
The PR https://github.com/api-platform/admin/pull/460 has added custom code to manage empty values with a `sanitizeEmptyValues` prop, since it was not available anymore in react-admin 4 (it was in 3).

React-admin 4.4 has added back the `sanitizeEmptyValues` prop: https://github.com/marmelab/react-admin/pull/8188.

This PR then removes the custom code and enables the native `sanitizeEmptyValues` prop by default.