### PR TITLE
fix: inconsistencies between dark and light theme override

### DIFF
--- a/src/layout/themes.ts
+++ b/src/layout/themes.ts
@@ -54,6 +54,7 @@ export const lightTheme: RaThemeOptions = {
     mode: 'light',
   },
   components: {
+    ...defaultTheme.components,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore react-admin doesn't add its own components
     RaMenuItemLink: {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #486
| License       | MIT

While overriding the `react-admin` theme, changes already made by `react-admin` to the `mui` theme for the components were imported for the dark mode but not for the light mode.

This PR re-adds those changes to the light mode.
