### PR TITLE
fixed: random error message about apiSchema being null

### DIFF
--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -197,7 +197,10 @@ export const IntrospectedEditGuesser = ({
       id={id}
       mutationMode={mutationMode}
       redirect={redirectTo}
-      transform={(data: Partial<RaRecord>) => ({ ...data, extraInformation: { hasFileField } })}
+      transform={(data: Partial<RaRecord>) => ({
+        ...data,
+        extraInformation: { hasFileField },
+      })}
       {...props}>
       <FormType
         onSubmit={mutationMode !== 'pessimistic' ? undefined : save}

--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -197,7 +197,7 @@ export const IntrospectedEditGuesser = ({
       id={id}
       mutationMode={mutationMode}
       redirect={redirectTo}
-      transform={(data) => ({ ...data, extraInformation: { hasFileField } })}
+      transform={(data: Partial<RaRecord>) => ({ ...data, extraInformation: { hasFileField } })}
       {...props}>
       <FormType
         onSubmit={mutationMode !== 'pessimistic' ? undefined : save}

--- a/src/__snapshots__/AdminGuesser.test.tsx.snap
+++ b/src/__snapshots__/AdminGuesser.test.tsx.snap
@@ -25,27 +25,7 @@ exports[`<AdminGuesser /> renders with custom resources 1`] = `
       "updateMany": [Function],
     }
   }
-  i18nProvider={
-    {
-      "changeLocale": [Function],
-      "getLocale": [Function],
-      "getLocales": [Function],
-      "translate": [Function],
-    }
-  }
   loading={[Function]}
-  store={
-    {
-      "getItem": [Function],
-      "removeItem": [Function],
-      "removeItems": [Function],
-      "reset": [Function],
-      "setItem": [Function],
-      "setup": [Function],
-      "subscribe": [Function],
-      "teardown": [Function],
-    }
-  }
 >
   <ResourceGuesser
     name="custom"
@@ -71,27 +51,7 @@ exports[`<AdminGuesser /> renders without custom resources 1`] = `
       "updateMany": [Function],
     }
   }
-  i18nProvider={
-    {
-      "changeLocale": [Function],
-      "getLocale": [Function],
-      "getLocales": [Function],
-      "translate": [Function],
-    }
-  }
   loading={[Function]}
-  store={
-    {
-      "getItem": [Function],
-      "removeItem": [Function],
-      "removeItems": [Function],
-      "reset": [Function],
-      "setItem": [Function],
-      "setup": [Function],
-      "subscribe": [Function],
-      "teardown": [Function],
-    }
-  }
 >
   <ResourceGuesser
     name="books"
@@ -117,26 +77,6 @@ exports[`<AdminGuesser /> renders without data 1`] = `
       "updateMany": [Function],
     }
   }
-  i18nProvider={
-    {
-      "changeLocale": [Function],
-      "getLocale": [Function],
-      "getLocales": [Function],
-      "translate": [Function],
-    }
-  }
   loading={[Function]}
-  store={
-    {
-      "getItem": [Function],
-      "removeItem": [Function],
-      "removeItems": [Function],
-      "reset": [Function],
-      "setItem": [Function],
-      "setup": [Function],
-      "subscribe": [Function],
-      "teardown": [Function],
-    }
-  }
 />
 `;

--- a/src/hydra/dataProvider.test.ts
+++ b/src/hydra/dataProvider.test.ts
@@ -201,16 +201,14 @@ describe('Transform a React Admin request to an Hydra request', () => {
       httpClient: mockFetchHydra,
       apiDocumentationParser: mockApiDocumentationParser,
     });
-    dataProvider.current
-      .create('resource', {
+    expect(() =>
+      dataProvider.current.create('resource', {
         data: {
           foo: 'foo',
           bar: 'baz',
         },
-      })
-      .catch((e) => {
-        expect(e).toMatch('error');
-      });
+      }),
+    ).not.toThrow(Error);
   });
 
   test('React Admin create', async () => {

--- a/src/hydra/dataProvider.test.ts
+++ b/src/hydra/dataProvider.test.ts
@@ -123,10 +123,6 @@ describe('Transform a React Admin request to an Hydra request', () => {
     }),
   };
 
-  beforeAll(async () => {
-    await dataProvider.current.introspect();
-  });
-
   test('React Admin get list with filter parameters and custom search params', async () => {
     mockFetchHydra.mockClear();
     mockFetchHydra.mockReturnValue(
@@ -193,6 +189,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         json: { '@id': '/foos/76' },
       }),
     );
+    await dataProvider.current.introspect();
     dataProvider.current = dataProviderFactory({
       entrypoint: 'entrypoint',
       mercure: {
@@ -220,6 +217,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         json: { '@id': '/foos/76' },
       }),
     );
+    await dataProvider.current.introspect();
     await dataProvider.current.create('resource', {
       data: {
         foo: 'foo',
@@ -245,6 +243,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         json: { '@id': '/foos/43' },
       }),
     );
+    await dataProvider.current.introspect();
 
     const file = new File(['foo'], 'foo.txt');
     const icons = [...Array(3).keys()].map((i) => ({
@@ -291,6 +290,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         json: { '@id': '/foos/23' },
       }),
     );
+    await dataProvider.current.introspect();
     await dataProvider.current.create('resource', {
       data: {
         bar: 'baz',
@@ -323,6 +323,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         json: { '@id': '/entrypoint/resource/1' },
       }),
     );
+    await dataProvider.current.introspect();
     await dataProvider.current.update('resource', {
       id: '/entrypoint/resource/1',
       data: {
@@ -352,6 +353,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
         json: { '@id': '/entrypoint/resource/1' },
       }),
     );
+    await dataProvider.current.introspect();
     await dataProvider.current.update('resource', {
       id: '/entrypoint/resource/1',
       data: {

--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -44,7 +44,7 @@ import type {
 const isPlainObject = (value: any): value is object =>
   lodashIsPlainObject(value);
 
-export var apiSchema: Api & { resources: Resource[] };
+let apiSchema: Api & { resources: Resource[] };
 
 class ReactAdminDocument implements ApiPlatformAdminRecord {
   originId?: string;

--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -44,6 +44,8 @@ import type {
 const isPlainObject = (value: any): value is object =>
   lodashIsPlainObject(value);
 
+export var apiSchema: Api & { resources: Resource[] };
+
 class ReactAdminDocument implements ApiPlatformAdminRecord {
   originId?: string;
 
@@ -193,8 +195,6 @@ function dataProvider(
         ...(factoryParams.mercure === true ? {} : factoryParams.mercure),
       }
     : null;
-
-  let apiSchema: Api & { resources: Resource[] };
 
   const convertReactAdminDataToHydraData = (
     resource: Resource,

--- a/src/layout/themes.ts
+++ b/src/layout/themes.ts
@@ -15,7 +15,7 @@ export const darkTheme: RaThemeOptions = {
       dark: '#21a1ae',
     },
     secondary: {
-      ...defaultTheme.palette.secondary,
+      ...defaultTheme.palette!.secondary,
       main: '#51b2bc',
     },
     mode: 'dark',
@@ -48,7 +48,7 @@ export const lightTheme: RaThemeOptions = {
       dark: '#006a75',
     },
     secondary: {
-      ...defaultTheme.palette.secondary,
+      ...defaultTheme.palette!.secondary,
       main: '#288690',
     },
     mode: 'light',

--- a/src/layout/themes.ts
+++ b/src/layout/themes.ts
@@ -15,7 +15,7 @@ export const darkTheme: RaThemeOptions = {
       dark: '#21a1ae',
     },
     secondary: {
-      ...defaultTheme.palette!.secondary,
+      ...defaultTheme.palette?.secondary,
       main: '#51b2bc',
     },
     mode: 'dark',
@@ -48,7 +48,7 @@ export const lightTheme: RaThemeOptions = {
       dark: '#006a75',
     },
     secondary: {
-      ...defaultTheme.palette!.secondary,
+      ...defaultTheme.palette?.secondary,
       main: '#288690',
     },
     mode: 'light',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | 

You randomly get a message saying `apiSchema` is null. This happened when the window lost and retrieved focus *twice* because the first time it lost focus it reconnected to the api endpoint and re-instantiated `dataProvider` without updating the Schema by reconnecting to `/`. Next time it tries to connect to the api endpoint, `apiSchema` which was a local variable was already lost.

This bug was notably happening in api-platform demo