### PR TITLE
Bump api-doc-parser to handle errors with application/problem+json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "sideEffects": false,
   "dependencies": {
-    "@api-platform/api-doc-parser": "^0.16.1",
+    "@api-platform/api-doc-parser": "^0.16.2",
     "history": "^5.0.0",
     "jsonld": "^8.1.0",
     "lodash.isplainobject": "^4.0.6",


### PR DESCRIPTION
A bug occurs when getting an error from API with `Content-Type` being `application/problem+json`.

Today this is not handled by the installed version of `api-doc-parser`, causing a generic server error to be thrown when using [fetchHydra](https://github.com/api-platform/admin/blob/main/src/hydra/fetchHydra.ts#L32C14-L32C14) for instance.

This is fixed in `api-doc-parser` [v0.16.2](https://github.com/api-platform/api-doc-parser/compare/v0.16.1...v0.16.2)

