### PR TITLE
passing expandSingle prop

### DIFF
--- a/src/ListGuesser.tsx
+++ b/src/ListGuesser.tsx
@@ -70,6 +70,7 @@ export const IntrospectedListGuesser = ({
   empty,
   hover,
   expand,
+  expandSingle,
   optimized,
   size,
   children,
@@ -122,6 +123,7 @@ export const IntrospectedListGuesser = ({
         empty={empty}
         hover={hover}
         expand={expand}
+        expandSingle={expandSingle}
         optimized={optimized}
         size={size}
         sx={datagridSx}>


### PR DESCRIPTION
ListGuesser exposures RA Datagrid `expand` panel feature, but without [ `expandSingle`](https://marmelab.com/react-admin/Datagrid.html#expandsingle) settings that makes it a bit incomplete, so here's an addition for that. 