### PR TITLE
Show|Create|EditGuesser viewComponent prop

### DIFF
--- a/src/CreateGuesser.tsx
+++ b/src/CreateGuesser.tsx
@@ -59,6 +59,7 @@ export const IntrospectedCreateGuesser = ({
   warnWhenUnsavedChanges,
   sanitizeEmptyValues = true,
   formComponent,
+  viewComponent,
   children,
   ...props
 }: IntrospectedCreateGuesserProps) => {
@@ -162,7 +163,7 @@ export const IntrospectedCreateGuesser = ({
   const FormType = hasFormTab ? TabbedForm : SimpleForm;
 
   return (
-    <Create resource={resource} {...props}>
+    <Create resource={resource} component={viewComponent} {...props}>
       <FormType
         onSubmit={save}
         mode={mode}

--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -62,6 +62,7 @@ export const IntrospectedEditGuesser = ({
   toolbar,
   warnWhenUnsavedChanges,
   formComponent,
+  viewComponent,
   sanitizeEmptyValues = true,
   children,
   ...props
@@ -197,6 +198,7 @@ export const IntrospectedEditGuesser = ({
       id={id}
       mutationMode={mutationMode}
       redirect={redirectTo}
+      component={viewComponent}
       transform={(data: Partial<RaRecord>) => ({
         ...data,
         extraInformation: { hasFileField },

--- a/src/ShowGuesser.tsx
+++ b/src/ShowGuesser.tsx
@@ -44,6 +44,7 @@ export const IntrospectedShowGuesser = ({
   writableFields,
   schema,
   schemaAnalyzer,
+  viewComponent,
   children,
   ...props
 }: IntrospectedShowGuesserProps) => {
@@ -70,7 +71,7 @@ export const IntrospectedShowGuesser = ({
   const ShowLayout = hasTab ? TabbedShowLayout : SimpleShowLayout;
 
   return (
-    <Show {...props}>
+    <Show component={viewComponent} {...props}>
       <ShowLayout>{fieldChildren}</ShowLayout>
     </Show>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,6 +370,7 @@ type CreateFormProps = Omit<
   CreateProps & SimpleFormProps & TabbedFormProps,
   'children'
 > &
+  Partial<PickRename<CreateProps, 'component', 'viewComponent'>> &
   Partial<
     PickRename<SimpleFormProps & TabbedFormProps, 'component', 'formComponent'>
   > & {
@@ -388,6 +389,7 @@ type EditFormProps = Omit<
   EditProps & SimpleFormProps & TabbedFormProps,
   'children'
 > &
+  Partial<PickRename<EditProps, 'component', 'viewComponent'>> &
   Partial<
     PickRename<SimpleFormProps & TabbedFormProps, 'component', 'formComponent'>
   > & {
@@ -421,9 +423,10 @@ export type ListGuesserProps = Omit<
 type ShowFormProps = Omit<
   ShowProps & SimpleFormProps & TabbedFormProps,
   'children'
-> & {
-  children?: ReactNode;
-};
+> &
+  Partial<PickRename<ShowProps, 'component', 'viewComponent'>> & {
+    children?: ReactNode;
+  };
 
 export type IntrospectedShowGuesserProps = ShowFormProps &
   IntrospectedGuesserProps;


### PR DESCRIPTION
In Create/EditGuesser form component can be customised by passing down `formComponent` prop as renamed `component` prop (to avoid name collision). Guessers use base RA components that also can take `component` prop for such customisation but it is omitted, so any further customisation needs a lot of code to assembly custom guesser replacement, so for completeness  and simplifying any customisation we can pass this other renamed component prop in this way. WDYT? 

See: 
- https://marmelab.com/react-admin/Show.html#component
- https://marmelab.com/react-admin/Create.html#component
- https://marmelab.com/react-admin/Edit.html#component