### PR TITLE
null violations error body fix

### DIFF
--- a/src/hydra/fetchHydra.ts
+++ b/src/hydra/fetchHydra.ts
@@ -4,7 +4,7 @@ import {
   getDocumentationUrlFromHeaders,
 } from '@api-platform/api-doc-parser';
 import jsonld from 'jsonld';
-import type { ContextDefinition, NodeObject } from 'jsonld';
+import type { NodeObject } from 'jsonld';
 import type { JsonLdObj } from 'jsonld/jsonld-spec';
 import type { HttpClientOptions, HydraHttpClientResponse } from '../types.js';
 
@@ -55,13 +55,11 @@ function fetchHydra(
         });
       };
 
-      return documentLoader(getDocumentationUrlFromHeaders(headers))
-        .then((response) =>
-          jsonld.expand(body, {
-            expandContext: response.document as ContextDefinition,
-          }),
-        )
-
+      return jsonld
+        .expand(body, {
+          base: getDocumentationUrlFromHeaders(headers),
+          documentLoader,
+        })
         .then((json) =>
           Promise.reject(
             new HttpError(


### PR DESCRIPTION
I seems that PR #515 broke violations list processing based on error body so validation messages are not shown any more in the form (?), this would never happen:

https://github.com/api-platform/admin/blob/a3292d81ddab39c04152e239e641920dd6f156ff/src/hydra/fetchHydra.ts#L79-L81

I think that we should step back and let jsonld do the math like it was in previous version. With this fix validation errors are shown again in the form. Please correct me if I missed anything here.