### PR TITLE
pass useEmbedded to mercure manager's data transformer

### DIFF
--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -701,8 +701,13 @@ function dataProvider(
     apiDocumentationParser,
     mercure: factoryParams.mercure ?? true,
   });
-  mercureManager.setDataTransformer(
-    transformJsonLdDocumentToReactAdminDocument,
+  mercureManager.setDataTransformer((jsonLdDocument) =>
+    transformJsonLdDocumentToReactAdminDocument(
+      jsonLdDocument,
+      true,
+      !disableCache,
+      useEmbedded,
+    ),
   );
 
   return {


### PR DESCRIPTION
Data provider does not pass `useEmbedded` setting to mercure manager's data transformer, default value (`false`) is always used  here.  

So if there is any embedded field on the list it is cleared (as side effect) by mercure update, ex:
```
  <NumberField
     label="Price"
     source="cost.price"
     options={{ style: "currency", currency: "EUR" }}
   />
```

fetched data:

```
      (...)
      "cost": {
        "@id": "/costs/375384",
        "@type": "https://schema.org/PriceSpecification",
        "price": 10,
        "priceCurrency": "EUR",
       },
```
But updated record that can't be properly rendered will be:

```
{
  (...)
  cost: '/costs/375384`,
}
```

This PR fix this passing `useEmbedded` prop to mercure dataTransformer.
