### PR TITLE
CreateGuesser / EditGuesser formId attribute to bind outher input elements

### DIFF
--- a/src/CreateGuesser.tsx
+++ b/src/CreateGuesser.tsx
@@ -58,6 +58,7 @@ export const IntrospectedCreateGuesser = ({
   toolbar,
   warnWhenUnsavedChanges,
   sanitizeEmptyValues = true,
+  formId,
   formComponent,
   viewComponent,
   children,
@@ -165,6 +166,7 @@ export const IntrospectedCreateGuesser = ({
   return (
     <Create resource={resource} component={viewComponent} {...props}>
       <FormType
+        id={formId}
         onSubmit={save}
         mode={mode}
         defaultValues={defaultValues}

--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -61,6 +61,7 @@ export const IntrospectedEditGuesser = ({
   transform,
   toolbar,
   warnWhenUnsavedChanges,
+  formId,
   formComponent,
   viewComponent,
   sanitizeEmptyValues = true,
@@ -205,6 +206,7 @@ export const IntrospectedEditGuesser = ({
       })}
       {...props}>
       <FormType
+        id={formId}
         onSubmit={mutationMode !== 'pessimistic' ? undefined : save}
         mode={mode}
         defaultValues={defaultValues}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ import type {
   DeleteResult,
   EditProps,
   EmailFieldProps,
+  FormProps,
   GET_LIST,
   GET_MANY,
   GET_MANY_REFERENCE,
@@ -371,6 +372,7 @@ type CreateFormProps = Omit<
   CreateProps & SimpleFormProps & TabbedFormProps,
   'children'
 > &
+  Partial<PickRename<FormProps, 'id', 'formId'>> &
   Partial<PickRename<CreateProps, 'component', 'viewComponent'>> &
   Partial<
     PickRename<SimpleFormProps & TabbedFormProps, 'component', 'formComponent'>
@@ -391,6 +393,7 @@ type EditFormProps = Omit<
   'children'
 > &
   Partial<PickRename<EditProps, 'component', 'viewComponent'>> &
+  Partial<PickRename<FormProps, 'id', 'formId'>> &
   Partial<
     PickRename<SimpleFormProps & TabbedFormProps, 'component', 'formComponent'>
   > & {


### PR DESCRIPTION
Possibility to set guesser's form id using `formId` attribute. It allows to place any [input element outside the form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#form). 


Example of submit button on the AppBar (just to show the idea, whole implementation uses  `React.createPortal()` and a bit more code):   

```
const AppBar  = () => (
   /...
  <SaveButton form="user-form" />
);
// ...

const UserCreate = () => (
    <CreateGuesser formId="user-form" (...)>
     // ...
    </CreateGuesser>
);
```
![obraz](https://github.com/api-platform/admin/assets/1256986/f26cb581-cec5-4025-992c-fbb1bfb07af4)
