### PR TITLE
useOnSubmit hook for Create/ EditGuesser

### DIFF
--- a/src/CreateGuesser.tsx
+++ b/src/CreateGuesser.tsx
@@ -1,23 +1,18 @@
-import React, { useCallback } from 'react';
-import type { PropsWithChildren, ReactNode } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Create,
-  FileInput,
   FormTab,
   SimpleForm,
   TabbedForm,
-  useCreate,
-  useNotify,
-  useRedirect,
   useResourceContext,
 } from 'react-admin';
-import type { HttpError, RaRecord } from 'react-admin';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
 import InputGuesser from './InputGuesser.js';
 import Introspecter from './Introspecter.js';
 import useDisplayOverrideCode from './useDisplayOverrideCode.js';
+import useOnSubmit from './useOnSubmit.js';
 import type {
   CreateGuesserProps,
   IntrospectedCreateGuesserProps,
@@ -63,9 +58,14 @@ export const IntrospectedCreateGuesser = ({
   children,
   ...props
 }: IntrospectedCreateGuesserProps) => {
-  const [create] = useCreate();
-  const notify = useNotify();
-  const redirect = useRedirect();
+  const save = useOnSubmit({
+    resource,
+    schemaAnalyzer,
+    fields,
+    mutationOptions,
+    transform,
+    redirectTo,
+  });
 
   const displayOverrideCode = useDisplayOverrideCode();
 
@@ -76,86 +76,6 @@ export const IntrospectedCreateGuesser = ({
     ));
     displayOverrideCode(getOverrideCode(schema, writableFields));
   }
-
-  const hasFileFieldElement = (elements: Array<ReactNode>): boolean =>
-    elements.some(
-      (child) =>
-        React.isValidElement(child) &&
-        (child.type === FileInput ||
-          hasFileFieldElement(
-            React.Children.toArray((child.props as PropsWithChildren).children),
-          )),
-    );
-  const hasFileField = hasFileFieldElement(inputChildren);
-
-  const save = useCallback(
-    async (values: Partial<RaRecord>) => {
-      let data = values;
-      if (transform) {
-        data = transform(values);
-      }
-      try {
-        const response = await create(
-          resource,
-          {
-            data,
-            meta: { hasFileField },
-          },
-          { returnPromise: true },
-        );
-        const success =
-          mutationOptions?.onSuccess ??
-          ((newRecord: RaRecord) => {
-            notify('ra.notification.created', {
-              type: 'info',
-              messageArgs: { smart_count: 1 },
-            });
-            redirect(redirectTo, resource, newRecord.id, newRecord);
-          });
-        success(response, { data: response }, {});
-        return undefined;
-      } catch (mutateError) {
-        const submissionErrors = schemaAnalyzer.getSubmissionErrors(
-          mutateError as HttpError,
-        );
-        const failure =
-          mutationOptions?.onError ??
-          ((error: string | Error) => {
-            let message = 'ra.notification.http_error';
-            if (!submissionErrors) {
-              message =
-                typeof error === 'string' ? error : error.message || message;
-            }
-            let errorMessage;
-            if (typeof error === 'string') {
-              errorMessage = error;
-            } else if (error?.message) {
-              errorMessage = error.message;
-            }
-            notify(message, {
-              type: 'warning',
-              messageArgs: { _: errorMessage },
-            });
-          });
-        failure(mutateError as string | Error, { data: values }, {});
-        if (submissionErrors) {
-          return submissionErrors;
-        }
-        return {};
-      }
-    },
-    [
-      create,
-      hasFileField,
-      resource,
-      mutationOptions,
-      notify,
-      redirect,
-      redirectTo,
-      schemaAnalyzer,
-      transform,
-    ],
-  );
 
   const hasFormTab = inputChildren.some(
     (child) =>

--- a/src/EditGuesser.tsx
+++ b/src/EditGuesser.tsx
@@ -1,26 +1,20 @@
-import React, { useCallback } from 'react';
-import type { PropsWithChildren, ReactNode } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Edit,
-  FileInput,
   FormTab,
   SimpleForm,
   TabbedForm,
-  useNotify,
-  useRedirect,
   useResourceContext,
-  useUpdate,
 } from 'react-admin';
-import type { HttpError, RaRecord } from 'react-admin';
 import { useParams } from 'react-router-dom';
 import type { Field, Resource } from '@api-platform/api-doc-parser';
 
 import InputGuesser from './InputGuesser.js';
 import Introspecter from './Introspecter.js';
-import getIdentifierValue from './getIdentifierValue.js';
 import useMercureSubscription from './useMercureSubscription.js';
 import useDisplayOverrideCode from './useDisplayOverrideCode.js';
+import useOnSubmit from './useOnSubmit.js';
 import type {
   EditGuesserProps,
   IntrospectedEditGuesserProps,
@@ -69,11 +63,15 @@ export const IntrospectedEditGuesser = ({
 }: IntrospectedEditGuesserProps) => {
   const { id: routeId } = useParams<'id'>();
   const id = decodeURIComponent(routeId ?? '');
+  const save = useOnSubmit({
+    resource,
+    schemaAnalyzer,
+    fields,
+    mutationOptions,
+    transform,
+    redirectTo,
+  });
   useMercureSubscription(resource, id);
-
-  const [update] = useUpdate();
-  const notify = useNotify();
-  const redirect = useRedirect();
 
   const displayOverrideCode = useDisplayOverrideCode();
 
@@ -84,108 +82,6 @@ export const IntrospectedEditGuesser = ({
     ));
     displayOverrideCode(getOverrideCode(schema, writableFields));
   }
-  const hasFileFieldElement = (elements: Array<ReactNode>): boolean =>
-    elements.some(
-      (child) =>
-        React.isValidElement(child) &&
-        (child.type === FileInput ||
-          hasFileFieldElement(
-            React.Children.toArray((child.props as PropsWithChildren).children),
-          )),
-    );
-  const hasFileField = hasFileFieldElement(inputChildren);
-
-  const save = useCallback(
-    async (values: Partial<RaRecord>) => {
-      if (id === undefined) {
-        return undefined;
-      }
-      let data = values;
-      if (transform) {
-        data = transform(values);
-      }
-      // Identifiers need to be formatted in case they have not been modified in the form.
-      Object.entries(values).forEach(([key, value]) => {
-        const identifierValue = getIdentifierValue(
-          schemaAnalyzer,
-          resource,
-          fields,
-          key,
-          value,
-        );
-        if (identifierValue !== value) {
-          data[key] = identifierValue;
-        }
-      });
-      try {
-        const response = await update(
-          resource,
-          {
-            id,
-            data,
-            meta: { hasFileField },
-          },
-          { returnPromise: true },
-        );
-        const success =
-          mutationOptions?.onSuccess ??
-          ((updatedRecord: RaRecord) => {
-            notify('ra.notification.updated', {
-              type: 'info',
-              messageArgs: { smart_count: 1 },
-            });
-            redirect(redirectTo, resource, updatedRecord.id, updatedRecord);
-          });
-        success(response, { id, data: response, previousData: values }, {});
-        return undefined;
-      } catch (mutateError) {
-        const submissionErrors = schemaAnalyzer.getSubmissionErrors(
-          mutateError as HttpError,
-        );
-        const failure =
-          mutationOptions?.onError ??
-          ((error: string | Error) => {
-            let message = 'ra.notification.http_error';
-            if (!submissionErrors) {
-              message =
-                typeof error === 'string' ? error : error.message || message;
-            }
-            let errorMessage;
-            if (typeof error === 'string') {
-              errorMessage = error;
-            } else if (error?.message) {
-              errorMessage = error.message;
-            }
-            notify(message, {
-              type: 'warning',
-              messageArgs: { _: errorMessage },
-            });
-          });
-        failure(
-          mutateError as string | Error,
-          { id, data: values, previousData: values },
-          {},
-        );
-        if (submissionErrors) {
-          return submissionErrors;
-        }
-        return {};
-      }
-    },
-    [
-      fields,
-      hasFileField,
-      id,
-      mutationOptions,
-      notify,
-      redirect,
-      redirectTo,
-      resource,
-      schemaAnalyzer,
-      transform,
-      update,
-    ],
-  );
 
   const hasFormTab = inputChildren.some(
     (child) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import ShowGuesser from './ShowGuesser.js';
 import useIntrospect from './useIntrospect.js';
 import useIntrospection from './useIntrospection.js';
 import useMercureSubscription from './useMercureSubscription.js';
+import useOnSubmit from './useOnSubmit.js';
 
 export {
   AdminGuesser,
@@ -26,6 +27,7 @@ export {
   useIntrospect,
   useIntrospection,
   useMercureSubscription,
+  useOnSubmit,
 };
 export {
   HydraAdmin,

--- a/src/types.ts
+++ b/src/types.ts
@@ -504,3 +504,10 @@ export type IntrospecterProps = (
   | ShowGuesserProps
 ) &
   BaseIntrospecterProps;
+
+export type UseOnSubmitProps = Pick<
+  IntrospectedGuesserProps,
+  'schemaAnalyzer' | 'resource' | 'fields'
+> &
+  Pick<CreateProps, 'mutationOptions' | 'transform'> &
+  PickRename<CreateProps, 'redirect', 'redirectTo'>;

--- a/src/useOnSubmit.test.tsx
+++ b/src/useOnSubmit.test.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import { jest } from '@jest/globals';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { CreateResult, RaRecord, UpdateResult } from 'react-admin';
+import { DataProviderContext, testDataProvider } from 'react-admin';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import useOnSubmit from './useOnSubmit.js';
+import schemaAnalyzer from './hydra/schemaAnalyzer.js';
+import { API_FIELDS_DATA } from './__fixtures__/parsedData.js';
+
+const dataProvider = testDataProvider({
+  create: jest.fn(() => Promise.resolve({ data: { id: 1 } } as CreateResult)),
+  update: jest.fn(() => Promise.resolve({ data: { id: 1 } } as UpdateResult)),
+});
+
+const onSubmitProps = {
+  fields: API_FIELDS_DATA,
+  resource: 'books',
+  schemaAnalyzer: schemaAnalyzer(),
+};
+
+jest.mock('./getIdentifierValue.js');
+
+test.each([
+  {
+    name: 'Book name 1',
+    authors: ['Author 1', 'Author 2'],
+    cover: { rawFile: new File(['content'], 'cover.png') },
+  },
+  {
+    name: 'Book name 2',
+    authors: ['Author 1', 'Author 2'],
+    covers: [
+      { rawFile: new File(['content1'], 'cover1.png') },
+      { rawFile: new File(['content2'], 'cover2.png') },
+    ],
+  },
+])(
+  'Call create with file input ($name)',
+  async (values: Omit<RaRecord, 'id'>) => {
+    let save;
+    const Dummy = () => {
+      const onSubmit = useOnSubmit(onSubmitProps);
+      save = onSubmit;
+      return <span />;
+    };
+    render(
+      <DataProviderContext.Provider value={dataProvider}>
+        <QueryClientProvider client={new QueryClient()}>
+          <MemoryRouter initialEntries={['/books/create']}>
+            <Routes>
+              <Route path="/books" element={<span />} />
+              <Route path="/books/create" element={<Dummy />} />
+              <Route path="/books/:id" element={<Dummy />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </DataProviderContext.Provider>,
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    save(values);
+    await waitFor(() => {
+      expect(dataProvider.create).toHaveBeenCalledWith('books', {
+        data: values,
+        meta: {
+          hasFileField: true,
+        },
+        previousData: undefined,
+      });
+    });
+  },
+);
+
+test.each([
+  {
+    id: '1',
+    name: 'Book name 1',
+    authors: ['Author 1', 'Author 2'],
+  },
+  {
+    id: '2',
+    name: 'Book name 2',
+    authors: ['Author 1', 'Author 2'],
+  },
+])('Call update without file inputs ($name)', async (values: RaRecord) => {
+  let save;
+  const Dummy = () => {
+    const onSubmit = useOnSubmit(onSubmitProps);
+    save = onSubmit;
+    return <span />;
+  };
+  render(
+    <DataProviderContext.Provider value={dataProvider}>
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter initialEntries={[`/books/${values.id}`]}>
+          <Routes>
+            <Route path="/books" element={<span />} />
+            <Route path="/books/:id" element={<Dummy />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </DataProviderContext.Provider>,
+  );
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  save(values);
+  await waitFor(() => {
+    expect(dataProvider.update).toHaveBeenCalledWith('books', {
+      id: values.id,
+      data: values,
+      meta: {
+        hasFileField: false,
+      },
+      previousData: undefined,
+    });
+  });
+});

--- a/src/useOnSubmit.ts
+++ b/src/useOnSubmit.ts
@@ -1,0 +1,135 @@
+import { useCallback } from 'react';
+import { useCreate, useNotify, useRedirect, useUpdate } from 'react-admin';
+import type { HttpError, RaRecord } from 'react-admin';
+import { useParams } from 'react-router-dom';
+import getIdentifierValue from './getIdentifierValue.js';
+import type { SubmissionErrors, UseOnSubmitProps } from './types.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const findFile = (values: any[]): object | undefined =>
+  values.find((value) =>
+    Array.isArray(value)
+      ? findFile(value)
+      : typeof value === 'object' && value.rawFile instanceof File,
+  );
+
+const useOnSubmit = ({
+  resource,
+  schemaAnalyzer,
+  fields,
+  mutationOptions,
+  redirectTo = 'list',
+  transform,
+}: UseOnSubmitProps): ((
+  values: Partial<RaRecord>,
+) => Promise<SubmissionErrors | undefined>) => {
+  const { id: routeId } = useParams<'id'>();
+  const id = decodeURIComponent(routeId ?? '');
+  const [create] = useCreate();
+  const [update] = useUpdate();
+  const notify = useNotify();
+  const redirect = useRedirect();
+
+  return useCallback(
+    async (values: Partial<RaRecord>) => {
+      const isCreate = id === undefined;
+      const data = transform ? transform(values) : values;
+
+      // Identifiers need to be formatted in case they have not been modified in the form.
+      if (!isCreate) {
+        Object.entries(values).forEach(([key, value]) => {
+          const identifierValue = getIdentifierValue(
+            schemaAnalyzer,
+            resource,
+            fields,
+            key,
+            value,
+          );
+          if (identifierValue !== value) {
+            data[key] = identifierValue;
+          }
+        });
+      }
+      try {
+        const response = await (isCreate ? create : update)(
+          resource,
+          {
+            ...(isCreate ? {} : { id }),
+            data,
+            meta: { hasFileField: !!findFile(Object.values(values)) },
+          },
+          { returnPromise: true },
+        );
+        const success =
+          mutationOptions?.onSuccess ??
+          ((record: RaRecord) => {
+            notify('ra.notification.updated', {
+              type: 'info',
+              messageArgs: { smart_count: 1 },
+            });
+            redirect(redirectTo, resource, record.id, record);
+          });
+        success(
+          response,
+          {
+            data: response,
+            ...(isCreate ? {} : { id, previousData: values }),
+          },
+          {},
+        );
+
+        return undefined;
+      } catch (mutateError) {
+        const submissionErrors = schemaAnalyzer.getSubmissionErrors(
+          mutateError as HttpError,
+        );
+        const failure =
+          mutationOptions?.onError ??
+          ((error: string | Error) => {
+            let message = 'ra.notification.http_error';
+            if (!submissionErrors) {
+              message =
+                typeof error === 'string' ? error : error.message || message;
+            }
+            let errorMessage;
+            if (typeof error === 'string') {
+              errorMessage = error;
+            } else if (error?.message) {
+              errorMessage = error.message;
+            }
+            notify(message, {
+              type: 'warning',
+              messageArgs: { _: errorMessage },
+            });
+          });
+        failure(
+          mutateError as string | Error,
+          {
+            data: values,
+            ...(isCreate ? {} : { id, previousData: values }),
+          },
+          {},
+        );
+        if (submissionErrors) {
+          return submissionErrors;
+        }
+        return {};
+      }
+    },
+    [
+      fields,
+      id,
+      mutationOptions,
+      notify,
+      redirect,
+      redirectTo,
+      resource,
+      schemaAnalyzer,
+      transform,
+      create,
+      update,
+    ],
+  );
+};
+
+export default useOnSubmit;

--- a/src/useOnSubmit.ts
+++ b/src/useOnSubmit.ts
@@ -18,8 +18,8 @@ const useOnSubmit = ({
   schemaAnalyzer,
   fields,
   mutationOptions,
-  redirectTo = 'list',
   transform,
+  redirectTo = 'list',
 }: UseOnSubmitProps): ((
   values: Partial<RaRecord>,
 ) => Promise<SubmissionErrors | undefined>) => {

--- a/src/useOnSubmit.ts
+++ b/src/useOnSubmit.ts
@@ -32,7 +32,7 @@ const useOnSubmit = ({
 
   return useCallback(
     async (values: Partial<RaRecord>) => {
-      const isCreate = id === undefined;
+      const isCreate = id === '';
       const data = transform ? transform(values) : values;
 
       // Identifiers need to be formatted in case they have not been modified in the form.


### PR DESCRIPTION
Refactored form submit handler and moved to stand alone hook. It makes easier to write custom form components with introspection without copy/ paste of `save` callback code from Guessers components. 

See #540.