### PR TITLE
fix: make it possible to pass all supported props by AdminContext from AdminGuesser

### DIFF
--- a/src/AdminGuesser.tsx
+++ b/src/AdminGuesser.tsx
@@ -113,8 +113,13 @@ const AdminGuesser = ({
   // Props for AdminResourcesGuesser
   includeDeprecated = false,
   // Admin props
+  basename,
+  store,
   dataProvider,
   i18nProvider,
+  authProvider,
+  queryClient,
+  defaultTheme,
   layout = Layout,
   loginPage = LoginPage,
   loading: loadingPage,
@@ -168,9 +173,14 @@ const AdminGuesser = ({
     <AdminContext
       i18nProvider={i18nProvider}
       dataProvider={dataProvider}
+      basename={basename}
+      authProvider={authProvider}
+      store={store}
+      queryClient={queryClient}
       theme={theme}
       darkTheme={darkTheme}
-      lightTheme={lightTheme}>
+      lightTheme={lightTheme}
+      defaultTheme={defaultTheme}>
       <IntrospectionContext.Provider value={introspectionContext}>
         <SchemaAnalyzerContext.Provider value={schemaAnalyzer}>
           <AdminResourcesGuesser


### PR DESCRIPTION
Fix passing down props from AdminGuesser to AdminContext.

