### PR TITLE
fix: pwa container crashes because packageManager is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,6 @@
     "storybook:build": "storybook build",
     "storybook:serve": "serve storybook-static",
     "storybook:test": "test-storybook"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
     "storybook:serve": "serve storybook-static",
     "storybook:test": "test-storybook"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@4.2.2"
 }

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
     "storybook:serve": "serve storybook-static",
     "storybook:test": "test-storybook"
   },
-  "packageManager": "yarn@4.2.2"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Problem

Running `docker compose up` throw the error: "The local project doesn't define a 'packageManager' field" for the pwa container

## Solution

Specify a `packageManager` in `package.json`


