### PR TITLE
cover react-admin undefined meta param

### DIFF
--- a/src/hydra/dataProvider.test.ts
+++ b/src/hydra/dataProvider.test.ts
@@ -333,6 +333,7 @@ describe('Transform a React Admin request to an Hydra request', () => {
       previousData: {
         id: '/entrypoint/resource/1',
       },
+      meta: undefined,
     });
     const url = mockFetchHydra.mock.calls?.[0]?.[0] ?? new URL('https://foo');
     expect(url).toBeInstanceOf(URL);

--- a/src/hydra/dataProvider.ts
+++ b/src/hydra/dataProvider.ts
@@ -351,10 +351,10 @@ function dataProvider(
       }
     });
     let extraInformation: { hasFileField?: boolean } = {};
-    if ('meta' in params) {
+    if (typeof params.meta === 'object') {
       extraInformation = params.meta;
     }
-    const updateHttpMethod = extraInformation?.hasFileField ? 'POST' : 'PUT';
+    const updateHttpMethod = extraInformation.hasFileField ? 'POST' : 'PUT';
 
     switch (type) {
       case CREATE:


### PR DESCRIPTION
Continuation of #498 that did not cover `undefined`  meta param what happen in case of using pure RA Edit/Create component, ex.:

https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/controller/edit/useEditController.ts#L159

Fix #555.