### PR TITLE
useOnSubmit - findFile null safe value access

### DIFF
--- a/src/useOnSubmit.test.tsx
+++ b/src/useOnSubmit.test.tsx
@@ -84,6 +84,12 @@ test.each([
     name: 'Book name 2',
     authors: ['Author 1', 'Author 2'],
   },
+  {
+    id: '3',
+    name: 'Book name 3',
+    authors: ['Author 1', 'Author 2'],
+    cover: null,
+  },
 ])('Call update without file inputs ($name)', async (values: RaRecord) => {
   let save;
   const Dummy = () => {

--- a/src/useOnSubmit.ts
+++ b/src/useOnSubmit.ts
@@ -2,15 +2,17 @@ import { useCallback } from 'react';
 import { useCreate, useNotify, useRedirect, useUpdate } from 'react-admin';
 import type { HttpError, RaRecord } from 'react-admin';
 import { useParams } from 'react-router-dom';
+import lodashIsPlainObject from 'lodash.isplainobject';
 import getIdentifierValue from './getIdentifierValue.js';
 import type { SubmissionErrors, UseOnSubmitProps } from './types.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const findFile = (values: any[]): object | undefined =>
+const findFile = (values: any[]): Blob | undefined =>
   values.find((value) =>
     Array.isArray(value)
       ? findFile(value)
-      : typeof value === 'object' && value.rawFile instanceof File,
+      : lodashIsPlainObject(value) &&
+        Object.values(value).find((val) => val instanceof File),
   );
 
 const useOnSubmit = ({


### PR DESCRIPTION
Fix for lack of null safe property access while looking for file input.

Fix #559 


Notice:  

IMHO usage of `hasFileField` meta property  should be dropped in favour of discovering File object by dataProvider itself, what is happening partly already ( `containFile` / `findFile` functions), and should be possible to override `updateHttpMethod`, multipart PUT request could be successfully processed on backend site by using for example `notihnio/php-request-parser` .