### PR TITLE
InputGuesser - incomplete typing for reference input

### DIFF
--- a/src/InputGuesser.test.tsx
+++ b/src/InputGuesser.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import type { SortPayload } from 'react-admin';
 import {
   AdminContext,
   Edit,
   ResourceContextProvider,
   SimpleForm,
-  SortPayload,
 } from 'react-admin';
 import { Resource } from '@api-platform/api-doc-parser';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -251,7 +251,10 @@ describe('<InputGuesser />', () => {
           <ResourceContextProvider value="users">
             <Edit id="/users/123" mutationMode="pessimistic">
               <SimpleForm>
-                <InputGuesser source="owner" sort={{field: "id", order: "DESC" } as SortPayload} />
+                <InputGuesser
+                  source="owner"
+                  sort={{ field: 'id', order: 'DESC' } as SortPayload}
+                />
               </SimpleForm>
             </Edit>
           </ResourceContextProvider>

--- a/src/InputGuesser.test.tsx
+++ b/src/InputGuesser.test.tsx
@@ -4,6 +4,7 @@ import {
   Edit,
   ResourceContextProvider,
   SimpleForm,
+  SortPayload,
 } from 'react-admin';
 import { Resource } from '@api-platform/api-doc-parser';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -241,6 +242,26 @@ describe('<InputGuesser />', () => {
         ],
       });
     });
+  });
+
+  test('renders reference input', async () => {
+    render(
+      <AdminContext dataProvider={dataProvider}>
+        <SchemaAnalyzerContext.Provider value={hydraSchemaAnalyzer}>
+          <ResourceContextProvider value="users">
+            <Edit id="/users/123" mutationMode="pessimistic">
+              <SimpleForm>
+                <InputGuesser source="owner" sort={{field: "id", order: "DESC" } as SortPayload} />
+              </SimpleForm>
+            </Edit>
+          </ResourceContextProvider>
+        </SchemaAnalyzerContext.Provider>
+      </AdminContext>,
+    );
+
+    expect(
+      await screen.findAllByText('resources.users.fields.owner'),
+    ).toHaveLength(1);
   });
 
   test.each([

--- a/src/InputGuesser.tsx
+++ b/src/InputGuesser.tsx
@@ -59,7 +59,7 @@ export const IntrospectedInputGuesser = ({
 
   if (field.reference !== null && typeof field.reference === 'object') {
     if (field.maxCardinality === 1) {
-      const { filter, page, perPage, sort, enableGetChoices } =
+      const { filter, page, perPage, sort, enableGetChoices, ...rest } =
         props as ReferenceInputProps;
 
       return (
@@ -75,13 +75,13 @@ export const IntrospectedInputGuesser = ({
           <SelectInput
             optionText={schemaAnalyzer.getFieldNameFromSchema(field.reference)}
             validate={guessedValidate}
-            {...(props as SelectInputProps)}
+            {...(rest as SelectInputProps)}
           />
         </ReferenceInput>
       );
     }
 
-    const { filter, page, perPage, sort, enableGetChoices } =
+    const { filter, page, perPage, sort, enableGetChoices, ...rest } =
       props as ReferenceArrayInputProps;
 
     return (
@@ -97,7 +97,7 @@ export const IntrospectedInputGuesser = ({
         <SelectArrayInput
           optionText={schemaAnalyzer.getFieldNameFromSchema(field.reference)}
           validate={guessedValidate}
-          {...(props as SelectArrayInputProps)}
+          {...(rest as SelectArrayInputProps)}
         />
       </ReferenceArrayInput>
     );

--- a/src/__fixtures__/parsedData.ts
+++ b/src/__fixtures__/parsedData.ts
@@ -111,4 +111,17 @@ export const API_FIELDS_DATA = [
     enum: { Epic: 'EPIC', 'Fairy tale': 'FAIRY_TALE', Myth: 'MYTH' },
     required: false,
   }),
+  new Field('owner', {
+    id: 'http://localhost/owner',
+    range: 'https://schema.org/Person',
+    reference: {
+      id: 'https://schema.org/Person',
+      name: 'users',
+      url: 'http://localhost/users',
+      fields: [],
+    },
+    embedded: null,
+    maxCardinality: 1,
+    required: false,
+  }),
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,30 +481,26 @@ type InputProps =
   | BooleanInputProps
   | NumberInputProps
   | ArrayInputProps
-  | (Pick<
-      ReferenceArrayInputProps,
-      'filter' | 'page' | 'perPage' | 'sort' | 'enableGetChoices'
-    > &
-      SelectArrayInputProps)
-  | (Pick<
-      ReferenceInputProps,
-      'filter' | 'page' | 'perPage' | 'sort' | 'enableGetChoices'
-    > &
-      SelectInputProps)
   | SelectArrayInputProps
   | SelectInputProps;
 
 export type IntrospectedInputGuesserProps = Partial<InputProps> &
   IntrospectedGuesserProps & {
     transformEnum?: (value: string | number) => string | number;
-  };
+  } & Pick<
+    ReferenceInputProps | ReferenceArrayInputProps,
+    'filter' | 'page' | 'perPage' | 'sort' | 'enableGetChoices'
+  >;
 
 export type InputGuesserProps = Omit<
   InputProps & Omit<BaseIntrospecterProps, 'resource'>,
   'component'
 > & {
   transformEnum?: (value: string | number) => string | number;
-};
+} & Pick<
+    ReferenceInputProps | ReferenceArrayInputProps,
+    'filter' | 'page' | 'perPage' | 'sort' | 'enableGetChoices'
+  >;
 
 export type IntrospecterProps = (
   | CreateGuesserProps

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ import type {
   ReferenceFieldProps,
   ReferenceInputProps,
   ResourceProps,
+  SelectArrayInputProps,
+  SelectInputProps,
   ShowProps,
   SimpleFormProps,
   SingleFieldListProps,
@@ -479,8 +481,10 @@ type InputProps =
   | BooleanInputProps
   | NumberInputProps
   | ArrayInputProps
-  | ReferenceArrayInputProps
-  | ReferenceInputProps;
+  | (ReferenceArrayInputProps & SelectArrayInputProps)
+  | (ReferenceInputProps & SelectInputProps)
+  | SelectArrayInputProps
+  | SelectInputProps;
 
 export type IntrospectedInputGuesserProps = Partial<InputProps> &
   IntrospectedGuesserProps & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,8 +481,16 @@ type InputProps =
   | BooleanInputProps
   | NumberInputProps
   | ArrayInputProps
-  | (ReferenceArrayInputProps & SelectArrayInputProps)
-  | (ReferenceInputProps & SelectInputProps)
+  | (Pick<
+      ReferenceArrayInputProps,
+      'filter' | 'page' | 'perPage' | 'sort' | 'enableGetChoices'
+    > &
+      SelectArrayInputProps)
+  | (Pick<
+      ReferenceInputProps,
+      'filter' | 'page' | 'perPage' | 'sort' | 'enableGetChoices'
+    > &
+      SelectInputProps)
   | SelectArrayInputProps
   | SelectInputProps;
 


### PR DESCRIPTION
Adds missing types to InputGuesserProps to allow usage of ReferenceInput/ ReferenceInputArray extra props (ex. `sort` or `filter`).

However test case still fails with _(updated, see below)_:
```
Property 'sort' does not exist on type (...)
```
Am I missing something (?)... I will come back to it when I have more time to dig it.


Fix: #561 
