### PR TITLE
ListGuesser rowClick propTypes RA compatibility

### DIFF
--- a/src/ListGuesser.tsx
+++ b/src/ListGuesser.tsx
@@ -158,7 +158,11 @@ ListGuesser.propTypes = {
   filters: PropTypes.element,
   hasShow: PropTypes.bool,
   hasEdit: PropTypes.bool,
-  rowClick: PropTypes.string,
+  rowClick: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.oneOf([false]),
+  ]),
 };
 /* eslint-enable tree-shaking/no-side-effects-in-initialization */
 


### PR DESCRIPTION
ListGuesser `rowClick` propType definition is too narrow (ex. passing `false` to disable it ends with console warnings), this PR makes it RA compatibility: 

https://marmelab.com/react-admin/Datagrid.html#rowclick