### PR TITLE
Fix default theme and store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Fix Inputs background in darkTheme
+* Fix default store isn't using localStorage
+
 ## 4.0.0
 
 * Compatibility with react-admin v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-* Fix Inputs background in darkTheme
-* Fix default store isn't using localStorage
-
 ## 4.0.0
 
 * Compatibility with react-admin v5

--- a/src/core/AdminGuesser.tsx
+++ b/src/core/AdminGuesser.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   AdminContext,
   defaultI18nProvider,
-  localStorageStore,
+  /* tree-shaking no-side-effects-when-called */ localStorageStore,
 } from 'react-admin';
 
 import type { ComponentType } from 'react';

--- a/src/core/AdminGuesser.tsx
+++ b/src/core/AdminGuesser.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { AdminContext, defaultI18nProvider } from 'react-admin';
+import {
+  AdminContext,
+  defaultI18nProvider,
+  localStorageStore,
+} from 'react-admin';
 
 import type { ComponentType } from 'react';
 import type { AdminProps } from 'react-admin';
@@ -12,8 +16,8 @@ import {
   Error as DefaultError,
   Layout,
   LoginPage,
-  darkTheme,
-  lightTheme,
+  darkTheme as defaultDarkTheme,
+  lightTheme as defaultLightTheme,
 } from '../layout/index.js';
 import type { ApiPlatformAdminDataProvider, SchemaAnalyzer } from '../types.js';
 
@@ -24,6 +28,8 @@ export interface AdminGuesserProps extends AdminProps {
   includeDeprecated?: boolean;
 }
 
+const defaultStore = localStorageStore();
+
 const AdminGuesser = ({
   // Props for SchemaAnalyzerContext
   schemaAnalyzer,
@@ -33,7 +39,7 @@ const AdminGuesser = ({
   basename,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error = DefaultError as any,
-  store,
+  store = defaultStore,
   dataProvider,
   i18nProvider = defaultI18nProvider,
   authProvider,
@@ -42,7 +48,8 @@ const AdminGuesser = ({
   layout = Layout,
   loginPage = LoginPage,
   loading: loadingPage,
-  theme = lightTheme,
+  theme = defaultLightTheme,
+  darkTheme = defaultDarkTheme,
   // Other props
   children,
   ...rest
@@ -98,7 +105,6 @@ const AdminGuesser = ({
       queryClient={queryClient}
       theme={theme}
       darkTheme={darkTheme}
-      lightTheme={lightTheme}
       defaultTheme={defaultTheme}>
       <IntrospectionContext.Provider value={introspectionContext}>
         <SchemaAnalyzerContext.Provider value={schemaAnalyzer}>

--- a/src/layout/themes.ts
+++ b/src/layout/themes.ts
@@ -34,6 +34,9 @@ export const darkTheme: RaThemeOptions = {
         },
       },
     },
+    MuiFilledInput: {
+      styleOverrides: undefined,
+    },
   },
 };
 


### PR DESCRIPTION
## Problem

The default HydraAdmin differs from react-admin in 2 ways:

1. The default store is memoryStore instead of localStorageStore. As a consequence, filters and sort preferences aren't persisted between sessions (and aren't auditable in devtools)
2. The inputs aren't legible in dark theme because they lack a background color

Also, it is not possible to customize the darkTheme.

## Solution

Use similar defaults as react-admin

| Before | After |
| --- | --- |
| <img width="668" alt="image" src="https://github.com/user-attachments/assets/a90a829c-580f-47da-be91-5b459ebf9813">|<img width="668" alt="image" src="https://github.com/user-attachments/assets/6811f8c6-a248-4567-b7f6-27e0df58b4cf">|


| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A
