### PR TITLE
fix(hydra): Fix server-side validation errors do not show up

### DIFF
--- a/src/hydra/fetchHydra.test.ts
+++ b/src/hydra/fetchHydra.test.ts
@@ -55,6 +55,32 @@ test.each([
         'At least one product must be selected if policy is restricted.',
     },
   ],
+  [
+    'problem+json',
+    {
+      '@context': '/contexts/ConstraintViolation',
+      '@id': '/validation_errors/2881c032-660f-46b6-8153-d352d9706640',
+      '@type': 'ConstraintViolation',
+      status: 422,
+      violations: [
+        {
+          propertyPath: 'isbn',
+          'ConstraintViolation/message':
+            'This value is neither a valid ISBN-10 nor a valid ISBN-13.',
+          'ConstraintViolation/code': '2881c032-660f-46b6-8153-d352d9706640',
+        },
+      ],
+      detail:
+        'isbn: This value is neither a valid ISBN-10 nor a valid ISBN-13.',
+      description:
+        'isbn: This value is neither a valid ISBN-10 nor a valid ISBN-13.',
+      type: '/validation_errors/2881c032-660f-46b6-8153-d352d9706640',
+      title: 'An error occurred',
+    },
+    {
+      isbn: 'This value is neither a valid ISBN-10 nor a valid ISBN-13.',
+    },
+  ],
 ])(
   '%s violation list expanding',
   async (format: string, resBody: object, expected: object) => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | 

## Issue

Contrary to what the [docs](https://api-platform.com/docs/admin/validation/#server-side-validation) say, server-side validation errors do not appear beneath the related input.

At least when using `<HydraAdmin>` with API Platform 4.1 using Symfony.

## Solution

Fix the `getSubmissionErrors` implementation.

Real-world tests show that validation errors are formatted like so:

```json
  "https://localhost/docs.jsonld#ConstraintViolation/violations": [
    {
      "https://localhost/docs.jsonld#ConstraintViolation/code": [
        {
          "@value": "2881c032-660f-46b6-8153-d352d9706640"
        }
      ],
      "https://localhost/docs.jsonld#ConstraintViolation/message": [
        {
          "@value": "This value is neither a valid ISBN-10 nor a valid ISBN-13."
        }
      ],
      "https://localhost/docs.jsonld#propertyPath": [
        {
          "@value": "isbn"
        }
      ]
    }
  ]
```

whereas the existing code seems to expect them like so:

```json
  "https://localhost/docs.jsonld#ConstraintViolation/violations": [
    {
      "https://localhost/docs.jsonld#code": [
        {
          "@value": "2881c032-660f-46b6-8153-d352d9706640"
        }
      ],
      "https://localhost/docs.jsonld#message": [
        {
          "@value": "This value is neither a valid ISBN-10 nor a valid ISBN-13."
        }
      ],
      "https://localhost/docs.jsonld#propertyPath": [
        {
          "@value": "isbn"
        }
      ]
    }
  ]
```

The new implementation I suggest is compatible with both.

## How to Test

A unit test was added.

Besides, this can be tested in Storybook.
1. Edit the `Book.php` file to add a constraint to the `$isbn` field: `#[Assert\Isbn]`
2. Start the api and storybook: `docker compose up`
3. Browse http://localhost:3000/?path=/story/admin-basic--admin
4. Try to edit a book with an invalid ISBN (any number really)
5. You should see the following error underneath the input

![Screenshot_20250408_151224](https://github.com/user-attachments/assets/4e814191-6919-4379-b73f-1ad8e4ed9ca6)
