### PR TITLE
omnit children prop in UseOnSubmitProps type

### DIFF
--- a/src/create/CreateGuesser.tsx
+++ b/src/create/CreateGuesser.tsx
@@ -73,7 +73,6 @@ export const IntrospectedCreateGuesser = ({
     mutationOptions,
     transform,
     redirectTo,
-    children: [],
   });
 
   const displayOverrideCode = useDisplayOverrideCode();

--- a/src/edit/EditGuesser.tsx
+++ b/src/edit/EditGuesser.tsx
@@ -78,7 +78,6 @@ export const IntrospectedEditGuesser = ({
     mutationOptions,
     transform,
     redirectTo,
-    children: [],
   });
   useMercureSubscription(resource, id);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -520,4 +520,4 @@ export type UseOnSubmitProps = Pick<
   'schemaAnalyzer' | 'resource' | 'fields'
 > &
   Pick<CreateProps, 'mutationOptions' | 'transform'> &
-  PickRename<CreateProps, 'redirect', 'redirectTo'>;
+  PickRename<Omit<CreateProps, 'children'>, 'redirect', 'redirectTo'>;

--- a/src/useOnSubmit.test.tsx
+++ b/src/useOnSubmit.test.tsx
@@ -19,7 +19,6 @@ const onSubmitProps = {
   fields: API_FIELDS_DATA,
   resource: 'books',
   schemaAnalyzer: schemaAnalyzer(),
-  children: [],
 };
 
 jest.mock('./getIdentifierValue.js');


### PR DESCRIPTION
Following RA ["Upgrading to v5"](https://marmelab.com/react-admin/Upgrade.html#editprops-and-createprops-now-expect-a-children-prop) it fixes  `UseOnSubmitProps` type to not to require unused `children` prop.

